### PR TITLE
Bump to avro 1.8.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,9 @@ scalaVersion := appConfiguration.value.provider.scalaProvider.version
 scalacOptions in Compile ++= Seq("-deprecation")
 
 libraryDependencies ++= Seq(
-  "org.apache.avro" % "avro" % "1.8.1",
-  "org.apache.avro" % "avro-compiler" % "1.8.1",
-  "org.apache.avro" % "avro-tools" % "1.8.1",
+  //"org.apache.avro" % "avro" % "1.8.1",
+  //"org.apache.avro" % "avro-compiler" % "1.8.1",
+  // "org.apache.avro" % "avro-tools" % "1.8.1",
   "org.specs2" %% "specs2-core" % "3.6.4" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,9 @@ scalaVersion := appConfiguration.value.provider.scalaProvider.version
 scalacOptions in Compile ++= Seq("-deprecation")
 
 libraryDependencies ++= Seq(
-  "org.apache.avro" % "avro" % "1.7.7",
-  "org.apache.avro" % "avro-compiler" % "1.7.7",
+  "org.apache.avro" % "avro" % "1.8.1",
+  "org.apache.avro" % "avro-compiler" % "1.8.1",
+  "org.apache.avro" % "avro-tools" % "1.8.1",
   "org.specs2" %% "specs2-core" % "3.6.4" % "test"
 )
 
@@ -19,7 +20,7 @@ licenses += ("BSD 3-Clause", url("https://github.com/sbt/sbt-avro/blob/master/LI
 publishMavenStyle := false
 bintrayOrganization := Some("sbt")
 bintrayRepository := "sbt-plugin-releases"
-bintrayPackage := "sbt-avro-1.7"
+bintrayPackage := "sbt-avro-1.8"
 bintrayReleaseOnPublish := false
 
 ScriptedPlugin.scriptedSettings

--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,8 @@ scalaVersion := appConfiguration.value.provider.scalaProvider.version
 scalacOptions in Compile ++= Seq("-deprecation")
 
 libraryDependencies ++= Seq(
-  //"org.apache.avro" % "avro" % "1.8.1",
-  //"org.apache.avro" % "avro-compiler" % "1.8.1",
-  // "org.apache.avro" % "avro-tools" % "1.8.1",
+  "org.apache.avro" % "avro" % "1.8.1",
+  "org.apache.avro" % "avro-compiler" % "1.8.1",
   "org.specs2" %% "specs2-core" % "3.6.4" % "test"
 )
 

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -36,7 +36,7 @@ object SbtAvro extends AutoPlugin {
       javaSource <<= (sourceManaged in Compile) { _ / "compiled_avro" },
       stringType := "CharSequence",
       fieldVisibility := "public_deprecated",
-      version := "1.7.3",
+      version := "1.8.1",
 
       managedClasspath <<= (classpathTypes, update) map { (ct, report) =>
         Classpaths.managedJars(avroConfig, ct, report)
@@ -86,7 +86,11 @@ object SbtAvro extends AutoPlugin {
 
     for (protocol <- (srcDir ** "*.avpr").get) {
       log.info("Compiling Avro protocol %s".format(protocol))
-      SpecificCompiler.compileProtocol(protocol.asFile, target)
+      val src = protocol.asFile
+      val avroProtocol = Protocol.parse(src)
+      val compiler = new SpecificCompiler(avroProtocol)
+      compiler.setStringType(stringType)
+      compiler.compileToDestination(src, target)
     }
 
     (target ** "*.java").get.toSet

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -8,6 +8,9 @@ import org.apache.avro.{Protocol, Schema}
 import org.apache.avro.compiler.idl.Idl
 import org.apache.avro.compiler.specific.SpecificCompiler
 import org.apache.avro.generic.GenericData.StringType
+import org.apache.avro.tool.SpecificCompilerTool
+import scala.collection.JavaConverters._
+
 
 import sbt._
 import sbt.ConfigKey.configurationToKey
@@ -91,8 +94,11 @@ object SbtAvro extends AutoPlugin {
       val compiler = new SpecificCompiler(avroProtocol)
       compiler.setStringType(stringType)
       compiler.compileToDestination(src, target)
+
     }
 
+    (new org.apache.avro.tool.SpecificCompilerTool).run(null, null, null, scala.collection.mutable.Buffer[String]("protocol", srcDir.toString, target.toString).asJava)
+   
     (target ** "*.java").get.toSet
   }
 

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -87,7 +87,7 @@ object SbtAvro extends AutoPlugin {
       compiler.compileToDestination(null, target)
     }
 
-    for (protocol <- (srcDir ** "*.avpr").get) {
+    /*for (protocol <- (srcDir ** "*.avpr").get) {
       log.info("Compiling Avro protocol %s".format(protocol))
       val src = protocol.asFile
       val avroProtocol = Protocol.parse(src)
@@ -95,7 +95,7 @@ object SbtAvro extends AutoPlugin {
       compiler.setStringType(stringType)
       compiler.compileToDestination(src, target)
 
-    }
+    }*/
 
     (new org.apache.avro.tool.SpecificCompilerTool).run(null, null, null, scala.collection.mutable.Buffer[String]("protocol", srcDir.toString, target.toString).asJava)
    

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -4,9 +4,10 @@ import java.io.File
 import scala.collection.mutable
 import scala.io.Source
 
-//import org.apache.avro.tool.SpecificCompilerTool
-
-//import scala.collection.JavaConverters._
+import org.apache.avro.{Protocol, Schema}
+import org.apache.avro.compiler.idl.Idl
+import org.apache.avro.compiler.specific.SpecificCompiler
+import org.apache.avro.generic.GenericData.StringType
 
 import sbt._
 import sbt.ConfigKey.configurationToKey
@@ -46,7 +47,6 @@ object SbtAvro extends AutoPlugin {
       managedSourceDirectories in Compile <+= (javaSource in avroConfig),
       cleanFiles <+= (javaSource in avroConfig),
       libraryDependencies <+= (version in avroConfig)("org.apache.avro" % "avro-compiler" % _),
-      //libraryDependencies <+= (version in avroConfig)("org.apache.avro" % "avro-tools" % _),
       ivyConfigurations += avroConfig
     )
   }
@@ -61,10 +61,6 @@ object SbtAvro extends AutoPlugin {
   override val projectSettings = avroSettings
 
   private[this] def compile(srcDir: File, target: File, log: Logger, stringTypeName: String, fieldVisibilityName: String) = {
-    import org.apache.avro.{Protocol, Schema}
-    import org.apache.avro.compiler.idl.Idl
-    import org.apache.avro.compiler.specific.SpecificCompiler
-    import org.apache.avro.generic.GenericData.StringType
     val stringType = StringType.valueOf(stringTypeName);
     log.info("Avro compiler using stringType=%s".format(stringType));
 
@@ -90,16 +86,9 @@ object SbtAvro extends AutoPlugin {
 
     for (protocol <- (srcDir ** "*.avpr").get) {
       log.info("Compiling Avro protocol %s".format(protocol))
-      //val src = protocol.asFile
-      //val avroProtocol = Protocol.parse(src)
-      //val compiler = new SpecificCompiler(avroProtocol)
-      //compiler.setStringType(stringType)
-      //compiler.compileToDestination(src, target)
       SpecificCompiler.compileProtocol(protocol.asFile, target)
     }
 
-    //(new org.apache.avro.tool.SpecificCompilerTool).run(null, null, null, scala.collection.mutable.Buffer[String]("protocol", srcDir.toString, target.toString).asJava)
-   
     (target ** "*.java").get.toSet
   }
 

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -4,13 +4,9 @@ import java.io.File
 import scala.collection.mutable
 import scala.io.Source
 
-import org.apache.avro.{Protocol, Schema}
-import org.apache.avro.compiler.idl.Idl
-import org.apache.avro.compiler.specific.SpecificCompiler
-import org.apache.avro.generic.GenericData.StringType
-import org.apache.avro.tool.SpecificCompilerTool
-import scala.collection.JavaConverters._
+//import org.apache.avro.tool.SpecificCompilerTool
 
+//import scala.collection.JavaConverters._
 
 import sbt._
 import sbt.ConfigKey.configurationToKey
@@ -39,7 +35,7 @@ object SbtAvro extends AutoPlugin {
       javaSource <<= (sourceManaged in Compile) { _ / "compiled_avro" },
       stringType := "CharSequence",
       fieldVisibility := "public_deprecated",
-      version := "1.8.1",
+      version := "1.7.3",
 
       managedClasspath <<= (classpathTypes, update) map { (ct, report) =>
         Classpaths.managedJars(avroConfig, ct, report)
@@ -50,6 +46,7 @@ object SbtAvro extends AutoPlugin {
       managedSourceDirectories in Compile <+= (javaSource in avroConfig),
       cleanFiles <+= (javaSource in avroConfig),
       libraryDependencies <+= (version in avroConfig)("org.apache.avro" % "avro-compiler" % _),
+      //libraryDependencies <+= (version in avroConfig)("org.apache.avro" % "avro-tools" % _),
       ivyConfigurations += avroConfig
     )
   }
@@ -64,6 +61,10 @@ object SbtAvro extends AutoPlugin {
   override val projectSettings = avroSettings
 
   private[this] def compile(srcDir: File, target: File, log: Logger, stringTypeName: String, fieldVisibilityName: String) = {
+    import org.apache.avro.{Protocol, Schema}
+    import org.apache.avro.compiler.idl.Idl
+    import org.apache.avro.compiler.specific.SpecificCompiler
+    import org.apache.avro.generic.GenericData.StringType
     val stringType = StringType.valueOf(stringTypeName);
     log.info("Avro compiler using stringType=%s".format(stringType));
 
@@ -87,17 +88,17 @@ object SbtAvro extends AutoPlugin {
       compiler.compileToDestination(null, target)
     }
 
-    /*for (protocol <- (srcDir ** "*.avpr").get) {
+    for (protocol <- (srcDir ** "*.avpr").get) {
       log.info("Compiling Avro protocol %s".format(protocol))
-      val src = protocol.asFile
-      val avroProtocol = Protocol.parse(src)
-      val compiler = new SpecificCompiler(avroProtocol)
-      compiler.setStringType(stringType)
-      compiler.compileToDestination(src, target)
+      //val src = protocol.asFile
+      //val avroProtocol = Protocol.parse(src)
+      //val compiler = new SpecificCompiler(avroProtocol)
+      //compiler.setStringType(stringType)
+      //compiler.compileToDestination(src, target)
+      SpecificCompiler.compileProtocol(protocol.asFile, target)
+    }
 
-    }*/
-
-    (new org.apache.avro.tool.SpecificCompilerTool).run(null, null, null, scala.collection.mutable.Buffer[String]("protocol", srcDir.toString, target.toString).asJava)
+    //(new org.apache.avro.tool.SpecificCompilerTool).run(null, null, null, scala.collection.mutable.Buffer[String]("protocol", srcDir.toString, target.toString).asJava)
    
     (target ** "*.java").get.toSet
   }


### PR DESCRIPTION
This just bumps the version. Generation follows whichever version this plugin is linked against, and not the version provided by the user. 