### PR TITLE
Added reminder for including settings in build.sbt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,10 @@ project directory::
 
     addSbtPlugin("com.cavorite" % "sbt-avro" % "0.3.2")
  
-
+And don't forget to include the settings line in ``build.sbt`` for the task to be activated during the build cycle
+ 
+    sbtavro.SbtAvro.avroSettings
+    
 Scope
 =====
 All settings and tasks are in the ``avro`` scope. If you want to execute the


### PR DESCRIPTION
At least with SBT 0.13.9 including the plugin is not enough for the task being autoincluded during the build. I had to include the above line in my `build.sbt` for it to work.

This PR just adds this reminder to the documentation for others with similar problems.