### PR TITLE
Enhance support for sorting dependent avsc files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,10 @@ Contributors
 - `Ashwanth Kumar`_
 - `Jérôme - Ch4mpy - Wacongne`_
 - `Ben McCann`_
+- `Ryan Koval`_
+- `Saket`_
+- `Julian Peeters`_
+- `Przemysław Dubaniewicz`_
 
 .. _`sbt Community`: http://www.scala-sbt.org/release/docs/Community-Plugins.html
 .. _`sbt-protobuf`: https://github.com/gseitz/sbt-protobuf
@@ -99,3 +103,7 @@ Contributors
 .. _`Ashwanth Kumar`: https://github.com/ashwanthkumar
 .. _`Jérôme - Ch4mpy - Wacongne`: https://github.com/ch4mpy
 .. _`Ben McCann`: http://www.benmccann.com
+.. _`Ryan Koval`: https://github.com/rkoval
+.. _`Saket`: https://github.com/skate056
+.. _`Julian Peeters`: https://github.com/julianpeeters
+.. _`Przemysław Dubaniewicz`: https://github.com/przemekd

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ scalacOptions in Compile ++= Seq("-deprecation")
 crossSbtVersions := Seq("0.13.16", "1.0.0")
 
 libraryDependencies ++= Seq(
+  "io.spray" %%  "spray-json" % "1.3.2",
   "org.apache.avro" % "avro" % "1.8.2",
   "org.apache.avro" % "avro-compiler" % "1.8.2",
   "org.specs2" %% "specs2-core" % "3.9.4" % "test"

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -1,5 +1,7 @@
 package sbtavro
 
+import filesorter.AvscFileSorter
+
 import java.io.File
 
 import scala.collection.mutable
@@ -98,7 +100,7 @@ object SbtAvro extends AutoPlugin {
       compileIdl(idl, target, stringType, fieldVisibility)
     }
 
-    for (avsc <- sortSchemaFiles((srcDir ** "*.avsc").get)) {
+    for (avsc <- AvscFileSorter.sortSchemaFiles((srcDir ** "*.avsc").get)) {
       log.info("Compiling Avro schema %s".format(avsc))
       compileAvsc(avsc, target, stringType, fieldVisibility)
     }
@@ -124,54 +126,5 @@ object SbtAvro extends AutoPlugin {
       }
     cachedCompile((srcDir ** "*.av*").get.toSet).toSeq
   }
-
-  def sortSchemaFiles(files: Traversable[File]): Seq[File] = {
-    val reversed = mutable.MutableList.empty[File]
-    var used: Traversable[File] = files
-    while(!used.isEmpty) {
-      val usedUnused = usedUnusedSchemas(used)
-      reversed ++= usedUnused._2
-      used = usedUnused._1
-    }
-    reversed.reverse.toSeq
-  }
-
-  def strContainsType(str: String, fullName: String): Boolean = {
-    val typeRegex = "\\\"type\\\"\\s*:\\s*(\\\"" + fullName + "\\\")|(\\[[^\\]]*\\\"" + fullName + "\\\"\\])"
-    typeRegex.r.findFirstIn(str).isDefined
-  }
-
-  def usedUnusedSchemas(files: Traversable[File]): (Traversable[File], Traversable[File]) = {
-    val usedUnused = files.map { f =>
-      val fullName = extractFullName(f)
-      (f, files.count { candidate =>
-        strContainsType(fileText(candidate), fullName)
-      } )
-    }.partition(_._2 > 0)
-    (usedUnused._1.map(_._1), usedUnused._2.map(_._1))
-  }
-
-  def extractFullName(f: File): String = {
-    val txt = fileText(f)
-    val namespace = namespaceRegex.findFirstMatchIn(txt)
-    val name = nameRegex.findFirstMatchIn(txt)
-    if(namespace == None) {
-      return name.get.group(1)
-    } else {
-      return s"${namespace.get.group(1)}.${name.get.group(1)}"
-    }
-  }
-
-  def fileText(f: File): String = {
-    val src = Source.fromFile(f)
-    try {
-      return src.getLines.mkString
-    } finally {
-      src.close()
-    }
-  }
-
-  val namespaceRegex = "\\\"namespace\\\"\\s*:\\s*\"([^\\\"]+)\\\"".r
-  val nameRegex = "\\\"name\\\"\\s*:\\s*\"([^\\\"]+)\\\"".r
 
 }

--- a/src/main/scala/sbtavro/filesorter/AvscFileSorter.scala
+++ b/src/main/scala/sbtavro/filesorter/AvscFileSorter.scala
@@ -1,0 +1,70 @@
+package sbtavro
+package filesorter
+
+import TypeComparator.strContainsType
+
+import java.io.File
+
+import scala.collection.mutable
+import scala.io.Source
+
+/**
+  * The order in which avsc files are compiled depends on the underlying file
+  * system (under OSX its is alphabetical, under some linux distros it's not).
+  * This is an issue when you have a record type that is used in different
+  * other types. This ensures that dependent types are compiled in the
+  * correct order. Code adapted from https://github.com/ch4mpy/sbt-avro/blob/master/src/main/scala/com/c4soft/sbtavro/SbtAvro.scala
+  * by Jerome Wascongne
+  */
+object AvscFileSorter {
+
+  val namespaceRegex = "\\\"namespace\\\"\\s*:\\s*\"([^\\\"]+)\\\"".r
+  val nameRegex = "\\\"name\\\"\\s*:\\s*\"([^\\\"]+)\\\"".r
+
+  def sortSchemaFiles(files: Traversable[File]): Seq[File] = {
+    val sortedButReversed = mutable.MutableList.empty[File]
+
+    def normalizeInput(files: List[File]) = files.sortBy(file => file.getName)
+
+    var pending: Traversable[File] = normalizeInput(files.toList)
+    while (pending.nonEmpty) {
+      val (used, unused) = usedUnusedSchemas(pending)
+      sortedButReversed ++= unused
+      pending = used
+    }
+    sortedButReversed.reverse
+  }
+
+  def usedUnusedSchemas(files: Traversable[File]): (Traversable[File], Traversable[File]) = {
+    val usedUnused = files.map { file =>
+      val fullName = extractFullName(file)
+      val numUsages = files.count { candidate =>
+        val candidateName = extractFullName(candidate)
+        strContainsType(candidateName, fileText(candidate), fullName)
+      }
+      (file, numUsages)
+    }.partition(usedUnused => usedUnused._2 > 0)
+    (usedUnused._1.map(_._1), usedUnused._2.map(_._1))
+  }
+
+  def extractFullName(f: File): String = {
+    val txt = fileText(f)
+    val namespace = namespaceRegex.findFirstMatchIn(txt)
+    val name = nameRegex.findFirstMatchIn(txt)
+    val nameGroup = name.get.group(1)
+    if (namespace.isEmpty) {
+      nameGroup
+    } else {
+      s"${namespace.get.group(1)}.$nameGroup"
+    }
+  }
+
+  def fileText(f: File): String = {
+    val src = Source.fromFile(f)
+    try {
+      src.getLines.mkString
+    } finally {
+      src.close()
+    }
+  }
+}

--- a/src/main/scala/sbtavro/filesorter/ReferredTypeFinder.scala
+++ b/src/main/scala/sbtavro/filesorter/ReferredTypeFinder.scala
@@ -1,0 +1,44 @@
+package sbtavro
+package filesorter
+
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+/**
+  * Code adapted from https://github.com/ch4mpy/sbt-avro/blob/master/src/main/scala/com/c4soft/sbtavro/SbtAvro.scala
+  * by Jerome Wascongne
+  */
+object ReferredTypeFinder {
+
+  def findReferredTypes(json: JsValue): List[String] = {
+
+    def matchComplexType(fields: Map[String, JsValue]): List[String] = {
+      val typeOfRef = fields(Keys.Type)
+      typeOfRef match {
+        case JsString(Keys.Array) => findReferredTypes(fields(Keys.Items))
+        case JsString(Keys.Enum) => List(fields(Keys.Name).convertTo[String])
+        case JsString(Keys.Record) => findReferredTypes(fields(Keys.Fields))
+        case nestedDefinition => findReferredTypes(nestedDefinition)
+      }
+    }
+
+    json match {
+      case str: JsString => List(str.value)
+      case union: JsArray => union.elements.toList.flatMap(findReferredTypes)
+      case complex: JsObject => matchComplexType(complex.fields)
+      case _ => List.empty
+    }
+
+  }
+
+  object Keys {
+    val Fields = "fields"
+    val Type = "type"
+    val Items = "items"
+    val Array = "array"
+    val Enum = "enum"
+    val Record = "record"
+    val Name = "name"
+  }
+
+}

--- a/src/main/scala/sbtavro/filesorter/TypeComparator.scala
+++ b/src/main/scala/sbtavro/filesorter/TypeComparator.scala
@@ -1,0 +1,41 @@
+package sbtavro
+package filesorter
+
+import spray.json._
+
+/**
+  * Code adapted from https://github.com/ch4mpy/sbt-avro/blob/master/src/main/scala/com/c4soft/sbtavro/SbtAvro.scala
+  * by Jerome Wascongne
+  */
+object TypeComparator {
+  /**
+    * This method is passed the full name of a query schema and checks if it
+    * appears in any of the current candidate schema's referred types.
+    */
+  def strContainsType(candidateName: String, str: String, name: String): Boolean = {
+    def isMatch(regex: String): Boolean = {
+      regex.r.findFirstIn(str).isDefined
+    }
+
+    val types = ReferredTypeFinder.findReferredTypes(str.parseJson)
+    val namespace = name.split("\\.") match {
+      case x if x.length == 1 => ""
+      case x => x.dropRight(1).mkString("\\.")
+    }
+    val namespaceRegex = "\\\"namespace\\\"\\s*:\\s*\\\"" + namespace + "\\\""
+    val isSameNamespace = isMatch(namespaceRegex)
+    val simpleTypeName = name.split("\\.").last
+    val simpleCandidateName = candidateName.split("\\.").last
+
+    val withoutSelf: List[String] = types
+      .filter(x => x != candidateName)
+      .filter(x => if (isSameNamespace) x != simpleCandidateName else true)
+
+    def isReferred(name: String): Boolean = {
+      withoutSelf.contains(name)
+    }
+
+    isReferred(name) || (isSameNamespace && isReferred(simpleTypeName))
+  }
+
+}

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/_a.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/_a.avsc
@@ -1,0 +1,27 @@
+{
+    "type": "record",
+    "namespace": "com.cavorite",
+    "name": "_A",
+    "doc": "Top-level schema testing simple dependent schema names",
+    "fields": [{
+            "doc": "dependent union field",
+            "name": "_b",
+            "type": ["null", "_B"]
+        },{
+            "doc": "dependent record field",
+            "name": "_c",
+            "type": "_C"
+        },{
+            "doc": "dependent array field",
+            "name": "_d",
+            "type": {
+              "type": "array",
+              "items": "_D"
+            }
+        },{
+            "doc": "dependent enum field",
+            "name": "_e",
+            "type": "_E"
+        }
+    ]
+}

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/_b.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/_b.avsc
@@ -1,0 +1,11 @@
+{
+    "type": "record",
+    "namespace": "com.cavorite",
+    "name": "_B",
+    "doc": "Simple dependency",
+    "fields": [{
+            "name": "_c",
+            "type": "_C"
+        }
+    ]
+}

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/_c.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/_c.avsc
@@ -1,0 +1,11 @@
+{
+    "type": "record",
+    "namespace": "com.cavorite",
+    "name": "_C",
+    "doc": "Simple dependency",
+    "fields": [{
+            "name": "bool",
+            "type": "boolean"
+        }
+    ]
+}

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/_d.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/_d.avsc
@@ -1,0 +1,11 @@
+{
+    "type": "record",
+    "namespace": "com.cavorite",
+    "name": "_D",
+    "doc": "Simple dependency",
+    "fields": [{
+            "name": "_c",
+            "type": "_C"
+        }
+    ]
+}

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/_e.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/_e.avsc
@@ -1,0 +1,7 @@
+{
+    "type": "enum",
+    "namespace": "com.cavorite",
+    "name": "_E",
+    "doc": "Simple dependency",
+    "symbols" : ["X", "XX", "XXX"]
+}

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/a.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/a.avsc
@@ -2,12 +2,29 @@
     "type": "record",
     "namespace": "com.cavorite",
     "name": "A",
+    "doc": "Top-level schema testing fully-qualified dependent schema names",
     "fields": [{
+            "doc": "fully-qualified dependent union field",
             "name": "b",
             "type": ["null", "com.cavorite.B"]
         },{
+            "doc": "fully-qualified dependent record field",
             "name": "c",
             "type": "com.cavorite.C"
+        },{
+            "doc": "fully-qualified dependent array field",
+            "name": "d",
+            "type": {
+                "type": "array",
+                "items": "com.cavorite.D"
+            }
+        },{
+            "doc": "fully-qualified dependent enum field",
+            "name": "e",
+            "type": {
+                "type": "array",
+                "items": "com.cavorite.E"
+            }
         }
     ]
 }

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/b.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/b.avsc
@@ -2,6 +2,7 @@
     "type": "record",
     "namespace": "com.cavorite",
     "name": "B",
+    "doc": "Fully-qualified dependency",
     "fields": [{
             "name": "c",
             "type": "com.cavorite.C"

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/c.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/c.avsc
@@ -1,6 +1,7 @@
 {
     "type": "record",
     "name": "com.cavorite.C",
+    "doc": "Fully-qualified dependency",
     "fields": [{
             "name": "str",
             "type": "string"

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/d.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/d.avsc
@@ -1,7 +1,6 @@
 {
     "type": "record",
-    "namespace": "com.cavorite",
-    "name": "B",
+    "name": "com.cavorite.D",
     "doc": "Fully-qualified dependency",
     "fields": [{
             "name": "c",

--- a/src/sbt-test/sbt-avro/basic/src/main/avro/e.avsc
+++ b/src/sbt-test/sbt-avro/basic/src/main/avro/e.avsc
@@ -1,0 +1,6 @@
+{
+  "type": "enum",
+  "doc": "Fully-qualified dependency",
+  "name": "com.cavorite.E",
+  "symbols" : ["A", "AA", "AAA"]
+}

--- a/src/sbt-test/sbt-avro/basic/test
+++ b/src/sbt-test/sbt-avro/basic/test
@@ -9,4 +9,26 @@ $ exists target/scala-2.11/classes/com/cavorite/B.class
 $ exists target/scala-2.11/src_managed/main/compiled_avro/com/cavorite/C.java
 $ exists target/scala-2.11/classes/com/cavorite/C.class
 
+$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/D.java
+$ exists target/scala-2.10/classes/com/cavorite/D.class
+
+$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/E.java
+$ exists target/scala-2.10/classes/com/cavorite/E.class
+
+
+$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_A.java
+$ exists target/scala-2.10/classes/com/cavorite/_A.class
+
+$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_B.java
+$ exists target/scala-2.10/classes/com/cavorite/_B.class
+
+$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_C.java
+$ exists target/scala-2.10/classes/com/cavorite/_C.class
+
+$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_D.java
+$ exists target/scala-2.10/classes/com/cavorite/_D.class
+
+$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_E.java
+$ exists target/scala-2.10/classes/com/cavorite/_E.class
+
 > clean

--- a/src/sbt-test/sbt-avro/basic/test
+++ b/src/sbt-test/sbt-avro/basic/test
@@ -9,26 +9,26 @@ $ exists target/scala-2.11/classes/com/cavorite/B.class
 $ exists target/scala-2.11/src_managed/main/compiled_avro/com/cavorite/C.java
 $ exists target/scala-2.11/classes/com/cavorite/C.class
 
-$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/D.java
-$ exists target/scala-2.10/classes/com/cavorite/D.class
+$ exists target/scala-2.11/src_managed/main/compiled_avro/com/cavorite/D.java
+$ exists target/scala-2.11/classes/com/cavorite/D.class
 
-$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/E.java
-$ exists target/scala-2.10/classes/com/cavorite/E.class
+$ exists target/scala-2.11/src_managed/main/compiled_avro/com/cavorite/E.java
+$ exists target/scala-2.11/classes/com/cavorite/E.class
 
 
-$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_A.java
-$ exists target/scala-2.10/classes/com/cavorite/_A.class
+$ exists target/scala-2.11/src_managed/main/compiled_avro/com/cavorite/_A.java
+$ exists target/scala-2.11/classes/com/cavorite/_A.class
 
-$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_B.java
-$ exists target/scala-2.10/classes/com/cavorite/_B.class
+$ exists target/scala-2.11/src_managed/main/compiled_avro/com/cavorite/_B.java
+$ exists target/scala-2.11/classes/com/cavorite/_B.class
 
-$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_C.java
-$ exists target/scala-2.10/classes/com/cavorite/_C.class
+$ exists target/scala-2.11/src_managed/main/compiled_avro/com/cavorite/_C.java
+$ exists target/scala-2.11/classes/com/cavorite/_C.class
 
-$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_D.java
-$ exists target/scala-2.10/classes/com/cavorite/_D.class
+$ exists target/scala-2.11/src_managed/main/compiled_avro/com/cavorite/_D.java
+$ exists target/scala-2.11/classes/com/cavorite/_D.class
 
-$ exists target/scala-2.10/src_managed/main/compiled_avro/com/cavorite/_E.java
-$ exists target/scala-2.10/classes/com/cavorite/_E.class
+$ exists target/scala-2.11/src_managed/main/compiled_avro/com/cavorite/_E.java
+$ exists target/scala-2.11/classes/com/cavorite/_E.class
 
 > clean

--- a/src/test/resources/avro/_a.avsc
+++ b/src/test/resources/avro/_a.avsc
@@ -1,0 +1,27 @@
+{
+    "type": "record",
+    "namespace": "com.cavorite",
+    "name": "_A",
+    "doc": "Top-level schema testing simple dependent schema names",
+    "fields": [{
+            "doc": "dependent union field",
+            "name": "_b",
+            "type": ["null", "_B"]
+        },{
+            "doc": "dependent record field",
+            "name": "_c",
+            "type": "_C"
+        },{
+            "doc": "dependent array field",
+            "name": "_d",
+            "type": {
+              "type": "array",
+              "items": "_D"
+            }
+        },{
+            "doc": "dependent enum field",
+            "name": "_e",
+            "type": "_E"
+        }
+    ]
+}

--- a/src/test/resources/avro/_b.avsc
+++ b/src/test/resources/avro/_b.avsc
@@ -1,0 +1,11 @@
+{
+    "type": "record",
+    "namespace": "com.cavorite",
+    "name": "_B",
+    "doc": "Simple dependency",
+    "fields": [{
+            "name": "_c",
+            "type": "_C"
+        }
+    ]
+}

--- a/src/test/resources/avro/_c.avsc
+++ b/src/test/resources/avro/_c.avsc
@@ -1,0 +1,11 @@
+{
+    "type": "record",
+    "namespace": "com.cavorite",
+    "name": "_C",
+    "doc": "Simple dependency",
+    "fields": [{
+            "name": "bool",
+            "type": "boolean"
+        }
+    ]
+}

--- a/src/test/resources/avro/_d.avsc
+++ b/src/test/resources/avro/_d.avsc
@@ -1,0 +1,11 @@
+{
+    "type": "record",
+    "namespace": "com.cavorite",
+    "name": "_D",
+    "doc": "Simple dependency",
+    "fields": [{
+            "name": "_c",
+            "type": "_C"
+        }
+    ]
+}

--- a/src/test/resources/avro/_e.avsc
+++ b/src/test/resources/avro/_e.avsc
@@ -1,0 +1,7 @@
+{
+    "type": "enum",
+    "namespace": "com.cavorite",
+    "name": "_E",
+    "doc": "Simple dependency",
+    "symbols" : ["X", "XX", "XXX"]
+}

--- a/src/test/resources/avro/a.avsc
+++ b/src/test/resources/avro/a.avsc
@@ -2,12 +2,29 @@
     "type": "record",
     "namespace": "com.cavorite",
     "name": "A",
+    "doc": "Top-level schema testing fully-qualified dependent schema names",
     "fields": [{
+            "doc": "fully-qualified dependent union field",
             "name": "b",
             "type": ["null", "com.cavorite.B"]
         },{
+            "doc": "fully-qualified dependent record field",
             "name": "c",
             "type": "com.cavorite.C"
+        },{
+            "doc": "fully-qualified dependent array field",
+            "name": "d",
+            "type": {
+                "type": "array",
+                "items": "com.cavorite.D"
+            }
+        },{
+            "doc": "fully-qualified dependent enum field",
+            "name": "e",
+            "type": {
+                "type": "array",
+                "items": "com.cavorite.E"
+            }
         }
     ]
 }

--- a/src/test/resources/avro/c.avsc
+++ b/src/test/resources/avro/c.avsc
@@ -1,6 +1,7 @@
 {
     "type": "record",
     "name": "com.cavorite.C",
+    "doc": "Fully-qualified dependency",
     "fields": [{
             "name": "str",
             "type": "string"

--- a/src/test/resources/avro/d.avsc
+++ b/src/test/resources/avro/d.avsc
@@ -1,7 +1,6 @@
 {
     "type": "record",
-    "namespace": "com.cavorite",
-    "name": "B",
+    "name": "com.cavorite.D",
     "doc": "Fully-qualified dependency",
     "fields": [{
             "name": "c",

--- a/src/test/resources/avro/e.avsc
+++ b/src/test/resources/avro/e.avsc
@@ -1,0 +1,6 @@
+{
+  "type": "enum",
+  "doc": "Fully-qualified dependency",
+  "name": "com.cavorite.E",
+  "symbols" : ["A", "AA", "AAA"]
+}

--- a/src/test/scala/sbtavro/SbtAvroSpec.scala
+++ b/src/test/scala/sbtavro/SbtAvroSpec.scala
@@ -1,41 +1,100 @@
 package sbtavro
 
+import filesorter.AvscFileSorter
+
 import java.io.File
 
-import org.apache.avro.Schema
 import org.apache.avro.compiler.specific.SpecificCompiler.FieldVisibility
 import org.apache.avro.generic.GenericData.StringType
 import org.specs2.mutable.Specification
 
 /**
- * Created by jeromewacongne on 06/08/2015.
- */
+  * Created by jeromewacongne on 06/08/2015.
+  */
 class SbtAvroSpec extends Specification {
   val sourceDir = new File(getClass.getClassLoader.getResource("avro").toURI)
   val targetDir = new File(sourceDir.getParentFile, "generated")
-  val sourceFiles = Seq(new File(sourceDir, "a.avsc"), new File(sourceDir, "b.avsc"), new File(sourceDir, "c.avsc"))
+
+  val fullyQualifiedNames = Seq(
+    new File(sourceDir, "a.avsc"),
+    new File(sourceDir, "b.avsc"),
+    new File(sourceDir, "c.avsc"),
+    new File(sourceDir, "d.avsc"),
+    new File(sourceDir, "e.avsc"))
+
+  val simpleNames = Seq(
+    new File(sourceDir, "_a.avsc"),
+    new File(sourceDir, "_b.avsc"),
+    new File(sourceDir, "_c.avsc"),
+    new File(sourceDir, "_d.avsc"),
+    new File(sourceDir, "_e.avsc"))
+
+  val expectedOrderFullyQualifiedNames = Seq(
+    new File(sourceDir, "c.avsc"),
+    new File(sourceDir, "e.avsc"),
+    new File(sourceDir, "d.avsc"),
+    new File(sourceDir, "b.avsc"),
+    new File(sourceDir, "a.avsc"))
+
+  val expectedOrderSimpleNames = Seq(
+    new File(sourceDir, "_c.avsc"),
+    new File(sourceDir, "_e.avsc"),
+    new File(sourceDir, "_d.avsc"),
+    new File(sourceDir, "_b.avsc"),
+    new File(sourceDir, "_a.avsc"))
+
+  val sourceFiles = fullyQualifiedNames ++ simpleNames
 
   "Schema files should be sorted with re-used types schemas first, whatever input order" >> {
-    SbtAvro.sortSchemaFiles(sourceFiles) must beEqualTo(Seq(new File(sourceDir, "c.avsc"), new File(sourceDir, "b.avsc"), new File(sourceDir, "a.avsc")))
-    SbtAvro.sortSchemaFiles(sourceFiles.reverse) must beEqualTo(Seq(new File(sourceDir, "c.avsc"), new File(sourceDir, "b.avsc"), new File(sourceDir, "a.avsc")))
+    AvscFileSorter.sortSchemaFiles(fullyQualifiedNames) must beEqualTo(expectedOrderFullyQualifiedNames)
+    AvscFileSorter.sortSchemaFiles(fullyQualifiedNames.reverse) must beEqualTo(expectedOrderFullyQualifiedNames)
+    AvscFileSorter.sortSchemaFiles(simpleNames) must beEqualTo(expectedOrderSimpleNames)
+    AvscFileSorter.sortSchemaFiles(simpleNames.reverse) must beEqualTo(expectedOrderSimpleNames)
   }
 
   "It should be possible to compile types depending on others if source files are provided in right order" >> {
-    val parser = new Schema.Parser()
     val packageDir = new File(targetDir, "com/cavorite")
+
     val aJavaFile = new File(packageDir, "A.java")
     val bJavaFile = new File(packageDir, "B.java")
     val cJavaFile = new File(packageDir, "C.java")
+    val dJavaFile = new File(packageDir, "D.java")
+    val eJavaFile = new File(packageDir, "E.java")
+
+    val _aJavaFile = new File(packageDir, "_A.java")
+    val _bJavaFile = new File(packageDir, "_B.java")
+    val _cJavaFile = new File(packageDir, "_C.java")
+    val _dJavaFile = new File(packageDir, "_D.java")
+    val _eJavaFile = new File(packageDir, "_E.java")
+
     aJavaFile.delete()
     bJavaFile.delete()
     cJavaFile.delete()
+    dJavaFile.delete()
+    eJavaFile.delete()
 
-    for(schemaFile <- SbtAvro.sortSchemaFiles(sourceFiles)) {
+    _aJavaFile.delete()
+    _bJavaFile.delete()
+    _cJavaFile.delete()
+    _dJavaFile.delete()
+    _eJavaFile.delete()
+
+    for (schemaFile <- AvscFileSorter.sortSchemaFiles(sourceFiles)) {
       SbtAvro.compileAvsc(schemaFile, targetDir, StringType.CharSequence, FieldVisibility.PUBLIC_DEPRECATED)
     }
 
     aJavaFile.isFile must beTrue
     bJavaFile.isFile must beTrue
     cJavaFile.isFile must beTrue
+    dJavaFile.isFile must beTrue
+    eJavaFile.isFile must beTrue
+
+    _aJavaFile.isFile must beTrue
+    _bJavaFile.isFile must beTrue
+    _cJavaFile.isFile must beTrue
+    _dJavaFile.isFile must beTrue
+    _eJavaFile.isFile must beTrue
+
   }
+
 }


### PR DESCRIPTION
Adds support for types within arrays and unions, and for non-fully-qualified type names (records that contain a namespace field). This work is copy-pasted from https://github.com/julianpeeters/sbt-avrohugger/tree/master/src/main/scala/sbtavrohugger, which itself was copy-pasted from this sbt-avro repo and modified by @rkoval, @skate056, @julianpeeters and @przemekd.

Fixes https://github.com/sbt/sbt-avro/issues/13