### PR TITLE
Specify UTF-8 as encoding when reading source file

### DIFF
--- a/src/main/scala/sbtavro/filesorter/AvscFileSorter.scala
+++ b/src/main/scala/sbtavro/filesorter/AvscFileSorter.scala
@@ -60,7 +60,7 @@ object AvscFileSorter {
   }
 
   def fileText(f: File): String = {
-    val src = Source.fromFile(f)
+    val src = Source.fromFile(f, "UTF-8")
     try {
       src.getLines.mkString
     } finally {


### PR DESCRIPTION
Relying on the default charset should be avoided as it varies based on
locale/collation. Setting it to UTF-8 should be generally safe, as files
saved with ASCII or ISO-8859-1 encoding will still open correctly.

Without it, an environment such as the Google cloud-builer for sbt will
error out if the file is saved as UTF-8.

Fixes #50 