### PR TITLE
Naive hotfix for #47 preventing Can't redefine: X

### DIFF
--- a/src/sbt-test/sbt-avro/settings/test
+++ b/src/sbt-test/sbt-avro/settings/test
@@ -3,3 +3,5 @@
 > test
 
 > clean
+
+> compile


### PR DESCRIPTION
This resets the SchemaParser on clean. I'm unaware of any state that stays around.