### PR TITLE
Bump to Apache Avro 1.9.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Name                Name in shell            Default                            
 ===============     ====================     ================================     ===============
 sourceDirectory     ``source-directory``     ``src/main/avro``                    Path containing ``*.avsc``, ``*.avdl`` and ``*.avpr`` files.
 javaSource          ``java-source``          ``$sourceManaged/compiled_avro``     Path for the generated ``*.java`` files.
-version             ``version``              ``1.9.0``                            Version of the Avro library should be used. A dependency to ``"org.apache.avro" % "avro-compiler" % "$version"`` is automatically added to ``libraryDependencies``.
+version             ``version``              ``1.9.1``                            Version of the Avro library should be used. A dependency to ``"org.apache.avro" % "avro-compiler" % "$version"`` is automatically added to ``libraryDependencies``.
 stringType          ``string-type``          ``CharSequence``                     Java type for string elements. Possible values: ``CharSequence`` (by default), ``Utf8`` and ``String``.
 useNamespace        ``use-namespace``        ``false``                            Validate that directory layout reflects namespaces, i.e. ``src/main/avro/com/myorg/MyRecord.avsc``.
 ===============     ====================     ================================     ===============

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Name                Name in shell            Default                            
 ===============     ====================     ================================     ===============
 sourceDirectory     ``source-directory``     ``src/main/avro``                    Path containing ``*.avsc``, ``*.avdl`` and ``*.avpr`` files.
 javaSource          ``java-source``          ``$sourceManaged/compiled_avro``     Path for the generated ``*.java`` files.
-version             ``version``              ``1.9.1``                            Version of the Avro library should be used. A dependency to ``"org.apache.avro" % "avro-compiler" % "$version"`` is automatically added to ``libraryDependencies``.
+version             ``version``              ``1.9.2``                            Version of the Avro library should be used. A dependency to ``"org.apache.avro" % "avro-compiler" % "$version"`` is automatically added to ``libraryDependencies``.
 stringType          ``string-type``          ``CharSequence``                     Java type for string elements. Possible values: ``CharSequence`` (by default), ``Utf8`` and ``String``.
 useNamespace        ``use-namespace``        ``false``                            Validate that directory layout reflects namespaces, i.e. ``src/main/avro/com/myorg/MyRecord.avsc``.
 ===============     ====================     ================================     ===============
@@ -80,7 +80,7 @@ Credits
 =======
 
 `sbt-avro` is maintained by the `sbt Community`_. The initial code was based on a
-similar plugin: `sbt-protobuf`_. Feel free to send your comments and bug 
+similar plugin: `sbt-protobuf`_. Feel free to send your comments and bug
 reports.
 
 Contributors

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -42,7 +42,7 @@ object SbtAvro extends AutoPlugin {
       fieldVisibility := "public_deprecated",
       enableDecimalLogicalType := true,
       useNamespace := false,
-      version := "1.9.1",
+      version := "1.9.2",
 
       managedClasspath := {
         Classpaths.managedJars(AvroConfig, classpathTypes.value, update.value)

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -42,7 +42,7 @@ object SbtAvro extends AutoPlugin {
       fieldVisibility := "public_deprecated",
       enableDecimalLogicalType := true,
       useNamespace := false,
-      version := "1.9.0",
+      version := "1.9.1",
 
       managedClasspath := {
         Classpaths.managedJars(AvroConfig, classpathTypes.value, update.value)


### PR DESCRIPTION
Since sbt-avro uses Version 1.9.1 internally, I think it is also a good idea to use it as the default version for the 1.9.x branch. It contains a couple of bugfixes.