### PR TITLE
Respect publishArtifact setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Avro sources (`*.avsc`, `*.avdl` and `*.avpr` files) can be packaged in a separa
 
 By default, `sbt-avro` does not publish this. You can enable it with
 ```sbt
-packageAvro / publishArtifact := true
+Compile / packageAvro / publishArtifact := true
 ```
 
 ## Declaring dependencies

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -47,9 +47,14 @@ object SbtAvro extends AutoPlugin {
     val packageAvro = taskKey[File]("Produces an avro artifact, such as a jar containing avro schemas.")
     // format: on
 
+    lazy val avroArtifactTasks: Seq[TaskKey[File]] = Seq(Compile, Test).map(_ / packageAvro)
+
     lazy val defaultSettings: Seq[Setting[_]] = Seq(
-      avroDependencyIncludeFilter := artifactFilter(`type` = Artifact.SourceType, classifier = AvroClassifier)
-    ) ++ addArtifact(Compile / packageAvro / artifact, Compile / packageAvro)
+      avroDependencyIncludeFilter := artifactFilter(`type` = Artifact.SourceType, classifier = AvroClassifier),
+      // addArtifact doesn't take publishArtifact setting in account
+      artifacts ++= Classpaths.artifactDefs(avroArtifactTasks).value,
+      packagedArtifacts ++= Classpaths.packaged(avroArtifactTasks).value,
+    )
 
     // settings to be applied for both Compile and Test
     lazy val configScopedSettings: Seq[Setting[_]] = Seq(

--- a/src/sbt-test/sbt-avro/publishing/build.sbt
+++ b/src/sbt-test/sbt-avro/publishing/build.sbt
@@ -16,7 +16,7 @@ lazy val `external`: Project = project
     version := "0.0.1-SNAPSHOT",
     crossPaths := false,
     autoScalaLibrary := false,
-    packageAvro / publishArtifact := true
+    Compile / packageAvro / publishArtifact := true
   )
 
 lazy val `transitive`: Project = project
@@ -26,7 +26,7 @@ lazy val `transitive`: Project = project
     name := "transitive",
     version := "0.0.1-SNAPSHOT",
     scalaVersion := "2.12.11",
-    packageAvro / publishArtifact := true,
+    Compile / packageAvro / publishArtifact := true,
     libraryDependencies ++= Seq(
       "com.cavorite" % "external" % "0.0.1-SNAPSHOT" classifier "avro",
     )


### PR DESCRIPTION
Fixes #29 

Manually tested with settings `publishArtifact` to false and `scripted`.
`master` is passing test even if `publishArtifact` setting is set to false.