### PR TITLE
Allow extra `avsc` file includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,6 @@ libraryDependencies += "org" % "name" % "rev" // module containing avro schemas
 avroDependencyIncludeFilter := avroDependencyIncludeFilter.value || moduleFilter(organization = "org", name = "name")
 ```
 
-Avro dependencies can be included in the compilation of your own `avsc` files:
-```
-avroIncludes := Seq((avroUnpackDependencies / target).value)
-```
-This means you can reference types defined in dependencies in your own avro schemas.
-
 # License
 This program is distributed under the BSD license. See the file `LICENSE` for more details.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ libraryDependencies += "org.apache.avro" % "avro" % "1.10.0"
 | `avroUnpackDependencies` / `target`  | `sourceManaged` / `avro`                   | Source directory for schemas packaged in the dependencies |
 | `avroGenerate` / `taget`             | `sourceManaged` / `compiled_avro`          | Source directory for generated `.java` files. |
 | `avroDependencyIncludeFilter`        | `source` typed `avro` classifier artifacts | Dependencies containing avro schema to be unpacked for generation |
+| `avroIncludes`                       | `Seq()`                                    | Paths with extra `*.avsc` files to be included in compilation. |
 | `packageAvro` / `artifactClassifier` | `Some("avro")`                             | Classifier for avro artifact |
 | `packageAvro` / `publishArtifact`    | `false`                                    | Enable / Disable avro artifact publishing |
 | `avroStringType`                     | `CharSequence`                             | Type for representing strings. Possible values: `CharSequence`, `String`, `Utf8`. |
@@ -88,6 +89,12 @@ setting to instruct the plugin to look for schemas in the desired dependency:
 libraryDependencies += "org" % "name" % "rev" // module containing avro schemas
 avroDependencyIncludeFilter := avroDependencyIncludeFilter.value || moduleFilter(organization = "org", name = "name")
 ```
+
+Avro dependencies can be included in the compilation of your own `avsc` files:
+```
+avroIncludes := Seq((avroUnpackDependencies / target).value)
+```
+This means you can reference types defined in dependencies in your own avro schemas.
 
 # License
 This program is distributed under the BSD license. See the file `LICENSE` for more details.

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val CompileOnly = config("compileonly").hide
 ThisBuild / dynverSonatypeSnapshots := true
 ThisBuild / version := {
   val orig = (ThisBuild / version).value
-  if (orig.endsWith("-SNAPSHOT")) "3.0.1-SNAPSHOT"
+  if (orig.endsWith("-SNAPSHOT")) "3.1.0-SNAPSHOT"
   else orig
 }
 

--- a/src/main/scala/sbtavro/SbtAvro.scala
+++ b/src/main/scala/sbtavro/SbtAvro.scala
@@ -135,18 +135,22 @@ object SbtAvro extends AutoPlugin {
     )
   }
 
-  def compileIdl(idl: File, target: File, stringType: StringType, fieldVisibility: FieldVisibility, enableDecimalLogicalType: Boolean) {
-    val parser = new Idl(idl)
-    val protocol = Protocol.parse(parser.CompilationUnit.toString)
-    val compiler = new SpecificCompiler(protocol)
-    compiler.setStringType(stringType)
-    compiler.setFieldVisibility(fieldVisibility)
-    compiler.setEnableDecimalLogicalType(enableDecimalLogicalType)
-    compiler.compileToDestination(null, target)
+  def compileIdls(idls: Seq[File], target: File, log: Logger, stringType: StringType, fieldVisibility: FieldVisibility, enableDecimalLogicalType: Boolean) = {
+    idls.foreach { idl =>
+      log.info(s"Compiling Avro IDL $idl")
+      val parser = new Idl(idl)
+      val protocol = Protocol.parse(parser.CompilationUnit.toString)
+      val compiler = new SpecificCompiler(protocol)
+      compiler.setStringType(stringType)
+      compiler.setFieldVisibility(fieldVisibility)
+      compiler.setEnableDecimalLogicalType(enableDecimalLogicalType)
+      compiler.compileToDestination(null, target)
+    }
   }
 
-  def compileAvscs(refs: Seq[AvroFileRef], target: File, stringType: StringType, fieldVisibility: FieldVisibility, enableDecimalLogicalType: Boolean, useNamespace: Boolean, builder: SchemaParserBuilder) {
+  def compileAvscs(refs: Seq[AvroFileRef], target: File, log: Logger, stringType: StringType, fieldVisibility: FieldVisibility, enableDecimalLogicalType: Boolean, useNamespace: Boolean, builder: SchemaParserBuilder) = {
     import com.spotify.avro.mojo._
+    import scala.collection.JavaConverters._
     val compiler = new AvscFilesCompiler(builder)
     compiler.setStringType(stringType)
     compiler.setFieldVisibility(fieldVisibility)
@@ -156,59 +160,49 @@ object SbtAvro extends AutoPlugin {
     compiler.setLogCompileExceptions(true)
     compiler.setTemplateDirectory("/org/apache/avro/compiler/specific/templates/java/classic/")
 
-    import scala.collection.JavaConverters._
+    refs.foreach { avsc =>
+      log.info(s"Compiling Avro schemas $avsc")
+    }
     compiler.compileFiles(refs.toSet.asJava, target)
   }
 
-  def compileAvpr(avpr: File, target: File, stringType: StringType, fieldVisibility: FieldVisibility, enableDecimalLogicalType: Boolean) {
-    val protocol = Protocol.parse(avpr)
-    val compiler = new SpecificCompiler(protocol)
-    compiler.setStringType(stringType)
-    compiler.setFieldVisibility(fieldVisibility)
-    compiler.setEnableDecimalLogicalType(enableDecimalLogicalType)
-    compiler.compileToDestination(null, target)
+  def compileAvprs(avprs: Seq[File], target: File, log: Logger, stringType: StringType, fieldVisibility: FieldVisibility, enableDecimalLogicalType: Boolean) = {
+    avprs.foreach { avpr =>
+      log.info(s"Compiling Avro protocol $avpr")
+      val protocol = Protocol.parse(avpr)
+      val compiler = new SpecificCompiler(protocol)
+      compiler.setStringType(stringType)
+      compiler.setFieldVisibility(fieldVisibility)
+      compiler.setEnableDecimalLogicalType(enableDecimalLogicalType)
+      compiler.compileToDestination(null, target)
+    }
   }
 
-  private[this] def compileAvroSchema(srcDir: File,
+  private[this] def compileAvroSchema(srcDirs: Seq[File],
                                       target: File,
-                                      includes: Seq[File],
                                       log: Logger,
                                       stringType: StringType,
                                       fieldVisibility: FieldVisibility,
                                       enableDecimalLogicalType: Boolean,
                                       useNamespace: Boolean,
                                       builder: SchemaParserBuilder): Set[File] = {
-    (srcDir ** AvroAvdlFilter).get.foreach { idl =>
-      log.info(s"Compiling Avro IDL $idl")
-      compileIdl(idl, target, stringType, fieldVisibility, enableDecimalLogicalType)
-    }
+    val avdls = srcDirs.flatMap(d => (d ** AvroAvdlFilter).get)
+    val avscs = srcDirs.flatMap(d => (d ** AvroAvscFilter).get.map(avsc => new AvroFileRef(d, avsc.relativeTo(d).get.toString)))
+    val avprs = srcDirs.flatMap(d => (d ** AvroAvrpFilter).get)
 
-    val includeAvscs = includes.flatMap { include =>
-      val includes = (include ** AvroAvscFilter).get
-      includes.foreach(s => log.info(s"Including: $s"))
-      includes.map(avsc => new AvroFileRef(include, avsc.relativeTo(include).get.toString))
-    }
-
-    val avscs = (srcDir ** AvroAvscFilter).get.map { avsc =>
-      log.info(s"Compiling Avro schemas $avsc")
-      new AvroFileRef(srcDir, avsc.relativeTo(srcDir).get.toString)
-    }
-
-    compileAvscs(includeAvscs ++ avscs, target, stringType, fieldVisibility, enableDecimalLogicalType, useNamespace, builder)
-
-    (srcDir ** AvroAvrpFilter).get.foreach { avpr =>
-      log.info(s"Compiling Avro protocol $avpr")
-      compileAvpr(avpr, target, stringType, fieldVisibility, enableDecimalLogicalType)
-    }
+    compileIdls(avdls, target, log, stringType, fieldVisibility, enableDecimalLogicalType)
+    compileAvscs(avscs, target, log, stringType, fieldVisibility, enableDecimalLogicalType, useNamespace, builder)
+    compileAvprs(avprs, target, log, stringType, fieldVisibility, enableDecimalLogicalType)
 
     (target ** JavaFileFilter).get.toSet
   }
 
   private def sourceGeneratorTask(key: TaskKey[Seq[File]]) = Def.task {
     val out = (key / streams).value
-    val externalSrcDir = (avroUnpackDependencies / target).value
     val srcDir = avroSource.value
+    val externalSrcDir = (avroUnpackDependencies / target).value
     val includes = avroIncludes.value
+    val srcDirs = Seq(externalSrcDir, srcDir) ++ includes
     val outDir = (key / target).value
     val strType = StringType.valueOf(avroStringType.value)
     val fieldVis = SpecificCompiler.FieldVisibility.valueOf(avroFieldVisibility.value.toUpperCase)
@@ -218,13 +212,11 @@ object SbtAvro extends AutoPlugin {
     val cachedCompile = {
       FileFunction.cached(out.cacheDirectory / "avro", FilesInfo.lastModified, FilesInfo.exists) { _ =>
         out.log.info(s"Avro compiler using stringType=$strType")
-        compileAvroSchema(externalSrcDir, outDir, Seq.empty, out.log, strType, fieldVis, enbDecimal, useNs, builder)
-        compileAvroSchema(srcDir, outDir, includes, out.log, strType, fieldVis, enbDecimal, useNs, builder)
-
+        compileAvroSchema(srcDirs, outDir, out.log, strType, fieldVis, enbDecimal, useNs, builder)
       }
     }
 
-    cachedCompile(((externalSrcDir +++ srcDir) ** AvroFilter).get.toSet).toSeq
+    cachedCompile((srcDirs ** AvroFilter).get.toSet).toSeq
   }
 
 }

--- a/src/sbt-test/sbt-avro/publishing/build.sbt
+++ b/src/sbt-test/sbt-avro/publishing/build.sbt
@@ -29,7 +29,8 @@ lazy val `transitive`: Project = project
     Compile / packageAvro / publishArtifact := true,
     libraryDependencies ++= Seq(
       "com.cavorite" % "external" % "0.0.1-SNAPSHOT" classifier "avro",
-    )
+    ),
+    avroIncludes := Seq((avroUnpackDependencies / target).value)
   )
 
 lazy val root: Project = project

--- a/src/sbt-test/sbt-avro/publishing/build.sbt
+++ b/src/sbt-test/sbt-avro/publishing/build.sbt
@@ -29,8 +29,7 @@ lazy val `transitive`: Project = project
     Compile / packageAvro / publishArtifact := true,
     libraryDependencies ++= Seq(
       "com.cavorite" % "external" % "0.0.1-SNAPSHOT" classifier "avro",
-    ),
-    avroIncludes := Seq((avroUnpackDependencies / target).value)
+    )
   )
 
 lazy val root: Project = project

--- a/src/sbt-test/sbt-avro/publishing/transitive/src/main/avro/com/cavorite/transitive/avsc.avsc
+++ b/src/sbt-test/sbt-avro/publishing/transitive/src/main/avro/com/cavorite/transitive/avsc.avsc
@@ -6,6 +6,10 @@
     {
       "name": "stringField",
       "type": "string"
+    },
+    {
+      "name": "referencedTypeField",
+      "type": "com.cavorite.external.Avsc"
     }
   ]
 }

--- a/src/test/scala/sbtavro/SbtAvroSpec.scala
+++ b/src/test/scala/sbtavro/SbtAvroSpec.scala
@@ -1,7 +1,6 @@
 package sbtavro
 
 import java.io.File
-import java.util.Collections
 
 import com.spotify.avro.mojo.AvroFileRef
 import org.apache.avro.compiler.specific.SpecificCompiler.FieldVisibility

--- a/src/test/scala/sbtavro/SbtAvroSpec.scala
+++ b/src/test/scala/sbtavro/SbtAvroSpec.scala
@@ -6,6 +6,7 @@ import com.spotify.avro.mojo.AvroFileRef
 import org.apache.avro.compiler.specific.SpecificCompiler.FieldVisibility
 import org.apache.avro.generic.GenericData.StringType
 import org.specs2.mutable.Specification
+import sbt.util.Logger
 
 /**
   * Created by jeromewacongne on 06/08/2015.
@@ -14,6 +15,7 @@ class SbtAvroSpec extends Specification {
   val builder = DefaultSchemaParserBuilder.default()
   val sourceDir = new File(getClass.getClassLoader.getResource("avro").toURI)
   val targetDir = new File(sourceDir.getParentFile, "generated")
+  val logger = Logger.Null
 
   val fullyQualifiedNames = Seq(
     new File(sourceDir, "a.avsc"),
@@ -73,7 +75,7 @@ class SbtAvroSpec extends Specification {
     _eJavaFile.delete()
 
     val refs = sourceFiles.map(s => new AvroFileRef(sourceDir, s.getName))
-    SbtAvro.compileAvscs(refs, targetDir, StringType.CharSequence, FieldVisibility.PUBLIC_DEPRECATED, true, false, builder)
+    SbtAvro.compileAvscs(refs, targetDir, logger, StringType.CharSequence, FieldVisibility.PUBLIC_DEPRECATED, true, false, builder)
 
     aJavaFile.isFile must beTrue
     bJavaFile.isFile must beTrue


### PR DESCRIPTION
Hey 👋 

We have a use case where we want to import 3rd party `avsc` files into our schemas to be able to reference the types defined inside. Since the avro library dependencies (`avroUnpackDependencies` / `target`) were compiled independently of the `avroSource` files, this was not possible.

This PR allows specifying additional `avroIncludes` and adds `avroUnpackDependencies` / `target` by default.

The behavior (apart from the default of `avroUnpackDependencies` / `target`) is similar to the `avro-maven-plugin`, where you can specify extra imports explicitly.
