### PR TITLE
Use distinct managed sources folders

### DIFF
--- a/src/sbt-test/sbt-avro/avscparser/test
+++ b/src/sbt-test/sbt-avro/avscparser/test
@@ -1,7 +1,7 @@
 > compile
 
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/A.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/B.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/A.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/B.java
 
 > test
 

--- a/src/sbt-test/sbt-avro/basic_current/test
+++ b/src/sbt-test/sbt-avro/basic_current/test
@@ -1,16 +1,16 @@
 > set avroSchemaParserBuilder := com.github.sbt.avro.DefaultSchemaParserBuilder.default().copy(validateDefaults = false)
 > avroGenerate
 
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/A.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/B.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/C.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/D.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/E.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/_A.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/_B.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/_C.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/_D.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/_E.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/A.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/B.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/C.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/D.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/E.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/_A.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/_B.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/_C.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/_D.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/_E.java
 
 > compile
 
@@ -27,9 +27,9 @@ $ exists target/scala-2.13/classes/com/github/sbt/avro/test/_E.class
 
 > test:compile
 
-$ exists target/scala-2.13/src_managed/test/compiled_avro/com/github/sbt/avro/test/X.java
-$ exists target/scala-2.13/src_managed/test/compiled_avro/com/github/sbt/avro/test/Y.java
-$ exists target/scala-2.13/src_managed/test/compiled_avro/com/github/sbt/avro/test/Z.java
+$ exists target/scala-2.13/src_managed/compiled_avro/test/com/github/sbt/avro/test/X.java
+$ exists target/scala-2.13/src_managed/compiled_avro/test/com/github/sbt/avro/test/Y.java
+$ exists target/scala-2.13/src_managed/compiled_avro/test/com/github/sbt/avro/test/Z.java
 $ exists target/scala-2.13/test-classes/com/github/sbt/avro/test/X.class
 $ exists target/scala-2.13/test-classes/com/github/sbt/avro/test/Y.class
 $ exists target/scala-2.13/test-classes/com/github/sbt/avro/test/Z.class

--- a/src/sbt-test/sbt-avro/publishing/build.sbt
+++ b/src/sbt-test/sbt-avro/publishing/build.sbt
@@ -43,7 +43,8 @@ lazy val root: Project = project
       "com.github.sbt" %% "transitive" % "0.0.1-SNAPSHOT" % Test classifier "tests",
       "org.specs2" %% "specs2-core" % "4.16.1" % Test
     ),
-    // make test only depend on
+    // add additional transitive test jar
     avroDependencyIncludeFilter := avroDependencyIncludeFilter.value || artifactFilter(name = "transitive_2.13", classifier = "tests"),
+    // exclude specific avsc file
     Compile / avroUnpackDependencies / excludeFilter := (Compile / avroUnpackDependencies / excludeFilter).value || "exclude.avsc"
   )

--- a/src/sbt-test/sbt-avro/publishing/build.sbt
+++ b/src/sbt-test/sbt-avro/publishing/build.sbt
@@ -27,6 +27,7 @@ lazy val `transitive`: Project = project
     name := "transitive",
     version := "0.0.1-SNAPSHOT",
     Compile / packageAvro / publishArtifact := true,
+    Test / publishArtifact := true,
     libraryDependencies ++= Seq(
       "com.github.sbt" % "external" % "0.0.1-SNAPSHOT" classifier "avro",
     )
@@ -37,12 +38,12 @@ lazy val root: Project = project
   .settings(commonSettings)
   .settings(
     name := "publishing-test",
-    avroDependencyIncludeFilter := avroDependencyIncludeFilter.value ||
-      // add avro jar to unpack its json avsc schema
-      moduleFilter(organization = "org.apache.avro", name = "avro"),
     libraryDependencies ++= Seq(
       "com.github.sbt" %% "transitive" % "0.0.1-SNAPSHOT" classifier "avro",
+      "com.github.sbt" %% "transitive" % "0.0.1-SNAPSHOT" % Test classifier "tests",
       "org.specs2" %% "specs2-core" % "4.16.1" % Test
     ),
+    // make test only depend on
+    avroDependencyIncludeFilter := avroDependencyIncludeFilter.value || artifactFilter(name = "transitive_2.13", classifier = "tests"),
     Compile / avroUnpackDependencies / excludeFilter := (Compile / avroUnpackDependencies / excludeFilter).value || "exclude.avsc"
   )

--- a/src/sbt-test/sbt-avro/publishing/src/main/scala/com/github/sbt/avro/test/Main.scala
+++ b/src/sbt-test/sbt-avro/publishing/src/main/scala/com/github/sbt/avro/test/Main.scala
@@ -1,6 +1,4 @@
-import com.github.sbt.avro.test.external
-import com.github.sbt.avro.test.transitive
-
+package com.github.sbt.avro.test
 
 object Main extends App {
 

--- a/src/sbt-test/sbt-avro/publishing/src/test/scala/com/github/sbt/avro/test/Test.scala
+++ b/src/sbt-test/sbt-avro/publishing/src/test/scala/com/github/sbt/avro/test/Test.scala
@@ -1,0 +1,10 @@
+package com.github.sbt.avro.test
+
+import com.github.sbt.avro.test.transitive.Test
+
+object AvroTest extends App {
+
+  Test.newBuilder().setStringField("external").build()
+
+  println("success")
+}

--- a/src/sbt-test/sbt-avro/publishing/test
+++ b/src/sbt-test/sbt-avro/publishing/test
@@ -8,20 +8,21 @@ $ exists external/target/external-0.0.1-SNAPSHOT-avro.jar
 
 > avroUnpackDependencies
 
-$ exists target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/external/avdl.avdl
-$ exists target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/external/avpr.avpr
-$ exists target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/external/avsc.avsc
-$ absent target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/external/exclude.avsc
-$ exists target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/transitive/avsc.avsc
-$ exists target/scala-2.13/src_managed/main/avro/org/apache/avro/data/Json.avsc
+$ exists target/scala-2.13/src_managed/avro/main/com/github/sbt/avro/test/external/avdl.avdl
+$ exists target/scala-2.13/src_managed/avro/main/com/github/sbt/avro/test/external/avpr.avpr
+$ exists target/scala-2.13/src_managed/avro/main/com/github/sbt/avro/test/external/avsc.avsc
+$ absent target/scala-2.13/src_managed/avro/main/com/github/sbt/avro/test/external/exclude.avsc
+
+$ exists target/scala-2.13/src_managed/avro/main/com/github/sbt/avro/test/transitive/avsc.avsc
+
+$ absent target/scala-2.13/src_managed/avro/main/com/github/sbt/avro/test/transitive/test.avsc
 
 > avroGenerate
 
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/external/Avdl.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/external/Avpr.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/external/Avsc.java
-$ absent target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/external/Excluded.java
-$ exists target/scala-2.13/src_managed/main/compiled_avro/com/github/sbt/avro/test/transitive/Avsc.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/external/Avdl.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/external/Avpr.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/external/Avsc.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/transitive/Avsc.java
 
 > compile
 
@@ -29,5 +30,11 @@ $ exists target/scala-2.13/classes/com/github/sbt/avro/test/external/Avdl.class
 $ exists target/scala-2.13/classes/com/github/sbt/avro/test/external/Avpr.class
 $ exists target/scala-2.13/classes/com/github/sbt/avro/test/external/Avsc.class
 $ exists target/scala-2.13/classes/com/github/sbt/avro/test/transitive/Avsc.class
+
+> Test/compile
+
+$ exists target/scala-2.13/src_managed/avro/test/test.avsc
+$ exists target/scala-2.13/src_managed/compiled_avro/test/com/github/sbt/avro/test/transitive/Test.java
+$ exists target/scala-2.13/test-classes/com/github/sbt/avro/test/transitive/Test.class
 
 > clean

--- a/src/sbt-test/sbt-avro/publishing/transitive/src/test/resources/test.avsc
+++ b/src/sbt-test/sbt-avro/publishing/transitive/src/test/resources/test.avsc
@@ -1,0 +1,15 @@
+{
+  "name": "Test",
+  "namespace": "com.github.sbt.avro.test.transitive",
+  "type": "record",
+  "fields": [
+    {
+      "name": "stringField",
+      "type": "string"
+    },
+    {
+      "name": "referencedTypeField",
+      "type": "com.github.sbt.avro.test.external.Avsc"
+    }
+  ]
+}

--- a/src/sbt-test/sbt-avro/settings/build.sbt
+++ b/src/sbt-test/sbt-avro/settings/build.sbt
@@ -9,4 +9,4 @@ avroStringType := "String"
 avroFieldVisibility := "public"
 avroOptionalGetters := true
 (Compile / avroSource) := (Compile / sourceDirectory).value / "avro_source"
-(Compile / avroGenerate / target) := (Compile / sourceManaged).value / "avro"
+(Compile / avroGenerate / target) := (Compile / sourceManaged).value

--- a/src/sbt-test/sbt-avro/settings/test
+++ b/src/sbt-test/sbt-avro/settings/test
@@ -1,10 +1,10 @@
 > compile
 
-$ exists target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/settings/Avdl.java
-$ exists target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/settings/Avpr.java
-$ exists target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/settings/ProtocolAvpr.java
-$ exists target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/settings/Avsc.java
-$ exists target/scala-2.13/src_managed/main/avro/com/github/sbt/avro/test/settings/ProtocolAvdl.java
+$ exists target/scala-2.13/src_managed/main/com/github/sbt/avro/test/settings/Avdl.java
+$ exists target/scala-2.13/src_managed/main/com/github/sbt/avro/test/settings/Avpr.java
+$ exists target/scala-2.13/src_managed/main/com/github/sbt/avro/test/settings/ProtocolAvpr.java
+$ exists target/scala-2.13/src_managed/main/com/github/sbt/avro/test/settings/Avsc.java
+$ exists target/scala-2.13/src_managed/main/com/github/sbt/avro/test/settings/ProtocolAvdl.java
 
 > test
 


### PR DESCRIPTION
Fix #125 

```diff
-target/scala-x.xx/src_managed/$config/avro/
+target/scala-x.xx/src_managed/avro/$config/

-target/scala-x.xx/src_managed/$config/compiled_avro/
+target/scala-x.xx/src_managed/compiled_avro/$config/
```

I'm not so sure on the schema libraries scoped in the test configuration. The compiler will regenerate java sources from the compile configuration, but I think there isn't a way around if the schema in test depend on a compile one.