### PR TITLE
Expose avro compiler version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ libraryDependencies += "org.apache.avro" % "avro-compiler" % "1.11.0"
 Add the library dependency to `build.sbt`:
 
 ```
-// Version must match that of `avro-compiler` in `project/plugins.sbt`
-libraryDependencies += "org.apache.avro" % "avro" % "1.11.0"
+libraryDependencies += "org.apache.avro" % "avro" % avroCompilerVersion
 ```
 
 ## Settings

--- a/src/sbt-test/sbt-avro/basic_1.10/build.sbt
+++ b/src/sbt-test/sbt-avro/basic_1.10/build.sbt
@@ -1,3 +1,3 @@
 name := "basic-test"
 scalaVersion := "2.13.6"
-libraryDependencies += "org.apache.avro" % "avro" % "1.10.2" // scala-steward:off
+libraryDependencies += "org.apache.avro" % "avro" % avroCompilerVersion

--- a/src/sbt-test/sbt-avro/basic_1.8/build.sbt
+++ b/src/sbt-test/sbt-avro/basic_1.8/build.sbt
@@ -1,3 +1,3 @@
 name := "basic-test"
 scalaVersion := "2.13.6"
-libraryDependencies += "org.apache.avro" % "avro" % "1.8.2" // scala-steward:off
+libraryDependencies += "org.apache.avro" % "avro" % avroCompilerVersion

--- a/src/sbt-test/sbt-avro/basic_1.9/build.sbt
+++ b/src/sbt-test/sbt-avro/basic_1.9/build.sbt
@@ -1,3 +1,3 @@
 name := "basic-test"
 scalaVersion := "2.13.6"
-libraryDependencies += "org.apache.avro" % "avro" % "1.9.2" // scala-steward:off
+libraryDependencies += "org.apache.avro" % "avro" % avroCompilerVersion

--- a/src/sbt-test/sbt-avro/basic_current/build.sbt
+++ b/src/sbt-test/sbt-avro/basic_current/build.sbt
@@ -1,3 +1,3 @@
 name := "basic-test"
 scalaVersion := "2.13.6"
-libraryDependencies += "org.apache.avro" % "avro" % "1.11.0" // scala-steward:off
+libraryDependencies += "org.apache.avro" % "avro" % avroCompilerVersion

--- a/src/sbt-test/sbt-avro/publishing/build.sbt
+++ b/src/sbt-test/sbt-avro/publishing/build.sbt
@@ -5,7 +5,7 @@ lazy val commonSettings = Seq(
   publishTo := Some(Opts.resolver.sonatypeReleases),
   scalaVersion := "2.13.6",
   libraryDependencies ++= Seq(
-    "org.apache.avro" % "avro" % "1.11.0"
+    "org.apache.avro" % "avro" % avroCompilerVersion
   )
 )
 

--- a/src/sbt-test/sbt-avro/sbt_1.3/build.sbt
+++ b/src/sbt-test/sbt-avro/sbt_1.3/build.sbt
@@ -1,3 +1,3 @@
 name := "basic-test"
 scalaVersion := "2.13.6"
-libraryDependencies += "org.apache.avro" % "avro" % "1.11.0"
+libraryDependencies += "org.apache.avro" % "avro" % avroCompilerVersion

--- a/src/sbt-test/sbt-avro/settings/build.sbt
+++ b/src/sbt-test/sbt-avro/settings/build.sbt
@@ -1,7 +1,7 @@
 name := "settings-test"
 scalaVersion := "2.13.6"
 libraryDependencies ++= Seq(
-  "org.apache.avro" % "avro" % "1.11.0",
+  "org.apache.avro" % "avro" % avroCompilerVersion,
   "org.specs2" %% "specs2-core" % "4.16.1" % Test
 )
 


### PR DESCRIPTION
Fix #19 

User can reference avro compiler version in their `build.sbt`

Compiler version is now set for avro pre 1.10. It was previously logging
```
 Avro compiler null using stringType=CharSequence
 ```
 