### PR TITLE
Enable recompilation when no avro schemas are in project

### DIFF
--- a/src/main/scala/com/github/sbt/avro/SbtAvro.scala
+++ b/src/main/scala/com/github/sbt/avro/SbtAvro.scala
@@ -279,6 +279,7 @@ object SbtAvro extends AutoPlugin {
   }
 
   private[this] def compileAvroSchema(
+    records: Seq[Class[_ <: SpecificRecord]],
     srcDirs: Seq[File],
     target: File,
     log: Logger,
@@ -294,6 +295,7 @@ object SbtAvro extends AutoPlugin {
     val avscs = srcDirs.flatMap(d => (d ** AvroAvscFilter).get.map(avsc => new AvroFileRef(d, avsc.relativeTo(d).get.toString)))
     val avprs = srcDirs.flatMap(d => (d ** AvroAvrpFilter).get)
 
+    recompile(records, target, log, stringType, fieldVisibility, enableDecimalLogicalType, useNamespace, optionalGetters, createSetters, builder)
     compileIdls(avdls, target, log, stringType, fieldVisibility, enableDecimalLogicalType, optionalGetters, createSetters)
     compileAvscs(avscs, target, log, stringType, fieldVisibility, enableDecimalLogicalType, useNamespace, optionalGetters, createSetters, builder)
     compileAvprs(avprs, target, log, stringType, fieldVisibility, enableDecimalLogicalType, optionalGetters, createSetters)
@@ -303,7 +305,7 @@ object SbtAvro extends AutoPlugin {
 
   private def sourceGeneratorTask(key: TaskKey[Seq[File]]) = Def.task {
     val out = (key / streams).value
-    val records = avroSpecificRecords.value
+
     val srcDir = avroSource.value
     val externalSrcDir = (avroUnpackDependencies / target).value
     val includes = avroIncludes.value
@@ -320,34 +322,51 @@ object SbtAvro extends AutoPlugin {
     }
     val builder = avroSchemaParserBuilder.value
     val cachedCompile = {
-      FileFunction.cached(out.cacheDirectory / "avro", FilesInfo.lastModified, FilesInfo.exists) { _ =>
-        out.log.info(s"Avro compiler $avroCompilerVersion using stringType=$strType")
-        compileAvroSchema(
-          srcDirs,
-          outDir,
-          out.log,
-          strType,
-          fieldVis,
-          enbDecimal,
-          useNs,
-          optionalGetters,
-          createSetters,
-          builder
-        )
+      import sbt.util.CacheStoreFactory
+      import sbt.util.CacheImplicits._
+
+      out.log.info(s"Avro compiler $avroCompilerVersion using stringType=$strType")
+
+      val cacheStoreFactory = CacheStoreFactory(out.cacheDirectory / "avro")
+      val lastCache = { (action: Option[Set[File]] => Set[File]) =>
+        Tracked.lastOutput[Unit, Set[File]](cacheStoreFactory.make("last-cache")) {
+          case (_, l) => action(l)
+        }.apply(())
       }
+      val inCache = Difference.inputs(cacheStoreFactory.make("in-cache"), FileInfo.lastModified)
+      val outCache = Difference.outputs(cacheStoreFactory.make("out-cache"), FileInfo.exists)
+
+      (inputs: Set[File], records: Seq[Class[_ <: SpecificRecord]]) =>
+        lastCache { lastCache =>
+          inCache(inputs) { inReport =>
+            outCache { outReport =>
+              if ((lastCache.isEmpty && records.nonEmpty) || inReport.modified.nonEmpty || outReport.modified.nonEmpty) {
+                // compile if
+                // - no previous cache and we have records to recompile
+                // - input files have changed
+                // - output files are missing
+                compileAvroSchema(
+                  records,
+                  srcDirs,
+                  outDir,
+                  out.log,
+                  strType,
+                  fieldVis,
+                  enbDecimal,
+                  useNs,
+                  optionalGetters,
+                  createSetters,
+                  builder
+                )
+              } else {
+                outReport.checked
+              }
+            }
+          }
+        }
     }
 
-    val recordOutputFiles = if(records.isEmpty) {
-      Set.empty[File]
-    } else {
-      recompile(
-        records, outDir, out.log, strType, fieldVis, enbDecimal, useNs,
-        optionalGetters, createSetters, builder
-      )
-      (outDir ** JavaFileFilter).get.toSet
-    }
-
-    (cachedCompile((srcDirs ** AvroFilter).get.toSet) ++ recordOutputFiles).toSeq
+    cachedCompile((srcDirs ** AvroFilter).get.toSet, avroSpecificRecords.value).toSeq
   }
 
 }

--- a/src/main/scala/com/github/sbt/avro/SbtAvro.scala
+++ b/src/main/scala/com/github/sbt/avro/SbtAvro.scala
@@ -295,6 +295,7 @@ object SbtAvro extends AutoPlugin {
     val avscs = srcDirs.flatMap(d => (d ** AvroAvscFilter).get.map(avsc => new AvroFileRef(d, avsc.relativeTo(d).get.toString)))
     val avprs = srcDirs.flatMap(d => (d ** AvroAvrpFilter).get)
 
+    log.info(s"Avro compiler $avroCompilerVersion using stringType=$stringType")
     recompile(records, target, log, stringType, fieldVisibility, enableDecimalLogicalType, useNamespace, optionalGetters, createSetters, builder)
     compileIdls(avdls, target, log, stringType, fieldVisibility, enableDecimalLogicalType, optionalGetters, createSetters)
     compileAvscs(avscs, target, log, stringType, fieldVisibility, enableDecimalLogicalType, useNamespace, optionalGetters, createSetters, builder)
@@ -324,8 +325,6 @@ object SbtAvro extends AutoPlugin {
     val cachedCompile = {
       import sbt.util.CacheStoreFactory
       import sbt.util.CacheImplicits._
-
-      out.log.info(s"Avro compiler $avroCompilerVersion using stringType=$strType")
 
       val cacheStoreFactory = CacheStoreFactory(out.cacheDirectory / "avro")
       val lastCache = { (action: Option[Set[File]] => Set[File]) =>

--- a/src/sbt-test/sbt-avro/recompile/build.sbt
+++ b/src/sbt-test/sbt-avro/recompile/build.sbt
@@ -1,0 +1,12 @@
+name := "recompile-test"
+scalaVersion := "2.13.11"
+libraryDependencies ++= Seq(
+  "org.apache.avro" % "avro" % avroCompilerVersion,
+  "org.specs2" %% "specs2-core" % "4.20.3" % Test
+)
+
+avroStringType := "String"
+avroFieldVisibility := "public"
+avroOptionalGetters := true
+avroEnableDecimalLogicalType := false
+Compile / avroSpecificRecords += classOf[org.apache.avro.specific.TestRecordWithLogicalTypes]

--- a/src/sbt-test/sbt-avro/recompile/project/build.properties
+++ b/src/sbt-test/sbt-avro/recompile/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.7

--- a/src/sbt-test/sbt-avro/recompile/project/plugins.sbt
+++ b/src/sbt-test/sbt-avro/recompile/project/plugins.sbt
@@ -1,0 +1,13 @@
+sys.props.get("plugin.version") match {
+  case Some(x) =>
+    println(s"fuuuck $x")
+    addSbtPlugin("com.github.sbt" % "sbt-avro" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+
+libraryDependencies ++= Seq(
+  "org.apache.avro" % "avro-compiler" % "1.11.3",
+  // depend on test jar to get some generated records in the build
+  "org.apache.avro" % "avro" % "1.11.3" classifier "tests"
+)

--- a/src/sbt-test/sbt-avro/recompile/project/plugins.sbt
+++ b/src/sbt-test/sbt-avro/recompile/project/plugins.sbt
@@ -1,6 +1,5 @@
 sys.props.get("plugin.version") match {
   case Some(x) =>
-    println(s"fuuuck $x")
     addSbtPlugin("com.github.sbt" % "sbt-avro" % x)
   case _ => sys.error("""|The system property 'plugin.version' is not defined.
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)

--- a/src/sbt-test/sbt-avro/recompile/record.avsc
+++ b/src/sbt-test/sbt-avro/recompile/record.avsc
@@ -1,0 +1,11 @@
+{
+    "name": "Record",
+    "namespace": "com.github.sbt.avro.test",
+    "type": "record",
+    "fields": [
+        {
+            "name": "value",
+            "type": "string"
+        }
+    ]
+}

--- a/src/sbt-test/sbt-avro/recompile/src/test/scala/com/github/sbt/avro/test/recompile/SettingsSpec.scala
+++ b/src/sbt-test/sbt-avro/recompile/src/test/scala/com/github/sbt/avro/test/recompile/SettingsSpec.scala
@@ -1,5 +1,0 @@
-package com.github.sbt.avro.test.recompile
-
-import org.specs2.mutable.Specification
-
-class SettingsSpec extends Specification {}

--- a/src/sbt-test/sbt-avro/recompile/src/test/scala/com/github/sbt/avro/test/recompile/SettingsSpec.scala
+++ b/src/sbt-test/sbt-avro/recompile/src/test/scala/com/github/sbt/avro/test/recompile/SettingsSpec.scala
@@ -1,0 +1,5 @@
+package com.github.sbt.avro.test.recompile
+
+import org.specs2.mutable.Specification
+
+class SettingsSpec extends Specification {}

--- a/src/sbt-test/sbt-avro/recompile/test
+++ b/src/sbt-test/sbt-avro/recompile/test
@@ -1,0 +1,11 @@
+> compile
+
+$ exists target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
+-$ exec grep BigDecimal target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
+-$ exec grep CharSequence target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
+
+> test
+
+> clean
+
+> compile

--- a/src/sbt-test/sbt-avro/recompile/test
+++ b/src/sbt-test/sbt-avro/recompile/test
@@ -3,9 +3,3 @@
 $ exists target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
 -$ exec grep BigDecimal target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
 -$ exec grep CharSequence target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
-
-> test
-
-> clean
-
-> compile

--- a/src/sbt-test/sbt-avro/recompile/test
+++ b/src/sbt-test/sbt-avro/recompile/test
@@ -1,5 +1,28 @@
-> compile
-
+> avroGenerate
 $ exists target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
--$ exec grep BigDecimal target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
--$ exec grep CharSequence target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
+
+# reference file created after 1st generation
+$ touch target/reference.txt
+
+# cache should not recompile
+> avroGenerate
+$ newer target/reference.txt target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
+
+# regenerate after clean
+> clean
+> avroGenerate
+$exists target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
+
+# add new source file should re-compile
+$ copy-file record.avsc src/main/avro/record.avsc
+> avroGenerate
+$ exists target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/Record.java
+$ exists target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java
+
+# update reference file
+$ touch target/reference.txt
+
+# cache should not recompile
+> avroGenerate
+$ newer target/reference.txt target/scala-2.13/src_managed/compiled_avro/main/com/github/sbt/avro/test/Record.java
+$ newer target/reference.txt target/scala-2.13/src_managed/compiled_avro/main/org/apache/avro/specific/TestRecordWithLogicalTypes.java


### PR DESCRIPTION
Currently a project without any avro schemas, but with a `avroSpecificRecords` configuration will not recompile those schemas.

If `avroSpecificRecords` contains records, this would always recompile those schemas.