### PR TITLE
Use avro scope for external avro sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If some artifact is meant to be used in the test scope only, you can do the foll
 
 ```sbt
 libraryDependencies += "org" % "name" % "rev" % "avro" classifier "avro"
-Compile / avroDependencyIncludeFilter := (Compile / avroDependencyIncludeFilter).value -- moduleFilter(organization = "org", name = "name")
+Compile / avroDependencyIncludeFilter ~= { old => old -- moduleFilter(organization = "org", name = "name") }
 Test / avroDependencyIncludeFilter := configurationFilter("avro") && moduleFilter(organization = "org", name = "name")
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ to generate the avro classes.
 | `avroAdditionalDependencies`   | `avro-compiler % avroVersion % "avro"`, `avro % avroVersion % "compile"` | Additional dependencies to be added to library dependencies.                            | 
 | `avroCompiler`                 | `com.github.sbt.avro.AvroCompilerBridge`                                 | Sbt avro compiler class.                                                                |
 | `avroCreateSetters`            | `true`                                                                   | Generate setters.                                                                       |
-| `avroDependencyIncludeFilter`  | `source` typed `avro` classifier artifacts                               | Filter for including modules containing avro dependencies.                              |
 | `avroEnableDecimalLogicalType` | `true`                                                                   | Use `java.math.BigDecimal` instead of `java.nio.ByteBuffer` for logical type `decimal`. |
 | `avroFieldVisibility`          | `public`                                                                 | Field visibility for the properties. Possible values: `private`, `public`.              |
 | `avroOptionalGetters`          | `false` (requires avro `1.10+`)                                          | Generate getters that return `Optional` for nullable fields.                            |
@@ -51,17 +50,18 @@ to generate the avro classes.
 
 ### Scoped settings (Compile/Test)
 
-| Name                                       | Default                                       | Description                                                                                          |
-|:-------------------------------------------|:----------------------------------------------|:-----------------------------------------------------------------------------------------------------|
-| `avroGenerate` / `target`                  | `sourceManaged` / `compiled_avro` / `$config` | Source directory for generated `.java` files.                                                        |
-| `avroSource`                               | `sourceDirectory` / `$config` / `avro`        | Default Avro source directory for `*.avsc`, `*.avdl` and `*.avpr` files.                             |
-| `avroSpecificRecords`                      | `Seq.empty`                                   | List of fully qualified Avro record class names to recompile with current avro version and settings. |
-| `avroUmanagedSourceDirectories`            | `Seq(avroSource)`                             | Unmanaged Avro source directories, which contain manually created sources.                           |
-| `avroUnpackDependencies` / `excludeFilter` | `HiddenFileFilter`                            | Filter for excluding avro specification files from unpacking.                                        |
-| `avroUnpackDependencies` / `includeFilter` | `AllPassFilter`                               | Filter for including avro specification files to unpack.                                             |
-| `avroUnpackDependencies` / `target`        | `sourceManaged` / `avro` / `$config`          | Target directory for schemas packaged in the dependencies                                            |
-| `packageAvro` / `artifactClassifier`       | `Some("avro")`                                | Classifier for avro artifact                                                                         |
-| `packageAvro` / `publishArtifact`          | `false`                                       | Enable / Disable avro artifact publishing                                                            |
+| Name                                       | Default                                                                                   | Description                                                                                          |
+|:-------------------------------------------|:------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------|
+| `avroGenerate` / `target`                  | `sourceManaged` / `compiled_avro` / `$config`                                             | Source directory for generated `.java` files.                                                        |
+| `avroSource`                               | `sourceDirectory` / `$config` / `avro`                                                    | Default Avro source directory for `*.avsc`, `*.avdl` and `*.avpr` files.                             |
+| `avroSpecificRecords`                      | `Seq.empty`                                                                               | List of fully qualified Avro record class names to recompile with current avro version and settings. |
+| `avroDependencyIncludeFilter`              | `Compile`: `source` typed `avro` classifier artifacts in `Avro` config<br>`Test`: nothing | Filter for including modules containing avro dependencies.                              |
+| `avroUmanagedSourceDirectories`            | `Seq(avroSource)`                                                                         | Unmanaged Avro source directories, which contain manually created sources.                           |
+| `avroUnpackDependencies` / `excludeFilter` | `HiddenFileFilter`                                                                        | Filter for excluding avro specification files from unpacking.                                        |
+| `avroUnpackDependencies` / `includeFilter` | `AllPassFilter`                                                                           | Filter for including avro specification files to unpack.                                             |
+| `avroUnpackDependencies` / `target`        | `sourceManaged` / `avro` / `$config`                                                      | Target directory for schemas packaged in the dependencies                                            |
+| `packageAvro` / `artifactClassifier`       | `Some("avro")`                                                                            | Classifier for avro artifact                                                                         |
+| `packageAvro` / `publishArtifact`          | `false`                                                                                   | Enable / Disable avro artifact publishing                                                            |
 
 
 ## Scoped Tasks (Compile/Test)
@@ -103,15 +103,23 @@ Compile / packageAvro / publishArtifact := true
 You can specify a dependency on an avro source artifact that contains the schemas like so:
 
 ```sbt
-libraryDependencies += "org" % "name" % "rev" classifier "avro"
+libraryDependencies += "org" % "name" % "rev" % "avro" classifier "avro"
 ```
 
 If some avro schemas are not packaged in a `source/avro` artifact, you can update the `avroDependencyIncludeFilter`
 setting to instruct the plugin to look for schemas in the desired dependency:
 
 ```sbt
-libraryDependencies += "org" % "name" % "rev" // module containing avro schemas
-avroDependencyIncludeFilter := avroDependencyIncludeFilter.value || moduleFilter(organization = "org", name = "name")
+libraryDependencies += "org" % "name" % "rev" % "avro" // module containing avro schemas
+Compile / avroDependencyIncludeFilter := configurationFilter("avro") && moduleFilter(organization = "org", name = "name")
+```
+
+If some artifact is meant to be used in the test scope only, you can do the following
+
+```sbt
+libraryDependencies += "org" % "name" % "rev" % "avro" classifier "avro"
+Compile / avroDependencyIncludeFilter := (Compile / avroDependencyIncludeFilter).value -- moduleFilter(organization = "org", name = "name")
+Test / avroDependencyIncludeFilter := configurationFilter("avro") && moduleFilter(organization = "org", name = "name")
 ```
 
 # License

--- a/plugin/src/sbt-test/sbt-avro/publishing/build.sbt
+++ b/plugin/src/sbt-test/sbt-avro/publishing/build.sbt
@@ -40,7 +40,7 @@ lazy val `transitive`: Project = project
     Compile / packageAvro / publishArtifact := true,
     Test / publishArtifact := true,
     libraryDependencies ++= Seq(
-      "com.github.sbt" % "external" % "0.0.1-SNAPSHOT" classifier "avro",
+      "com.github.sbt" % "external" % "0.0.1-SNAPSHOT" % "avro" classifier "avro",
     )
   )
 
@@ -52,12 +52,14 @@ lazy val root: Project = project
     name := "publishing-test",
     crossScalaVersions := Seq("2.13.15", "2.12.20"),
     libraryDependencies ++= Seq(
-      "com.github.sbt" % "transitive" % "0.0.1-SNAPSHOT" classifier "avro",
-      "com.github.sbt" % "transitive" % "0.0.1-SNAPSHOT" % Test classifier "tests",
+      "com.github.sbt" % "external" % "0.0.1-SNAPSHOT" % "avro" classifier "avro", // must be explicit
+      "com.github.sbt" % "transitive" % "0.0.1-SNAPSHOT" % "avro" classifier "avro",
+      "com.github.sbt" % "transitive" % "0.0.1-SNAPSHOT" % "avro" classifier "tests",
       "org.specs2" %% "specs2-core" % "4.20.9" % Test
     ),
-    // add additional transitive test jar
-    avroDependencyIncludeFilter := avroDependencyIncludeFilter.value || artifactFilter(name = "transitive", classifier = "tests"),
+    // add additional avro source test jar
+    Test / avroDependencyIncludeFilter :=
+      configurationFilter("avro") && artifactFilter(name = "transitive", classifier = "tests"),
     // exclude specific avsc file
     Compile / avroUnpackDependencies / excludeFilter := (Compile / avroUnpackDependencies / excludeFilter).value || "exclude.avsc",
 

--- a/plugin/src/sbt-test/sbt-avro/publishing/build.sbt
+++ b/plugin/src/sbt-test/sbt-avro/publishing/build.sbt
@@ -9,40 +9,44 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.13.15"
 )
 
-lazy val javaOnlySettings = Seq(
+lazy val avroOnlySettings = Seq(
   crossScalaVersions := Seq.empty,
   crossPaths := false,
   autoScalaLibrary := false,
+  // only create avro jar
+  Compile / packageAvro / publishArtifact := true,
+  Compile / packageBin / publishArtifact := false,
+  Compile / packageSrc / publishArtifact := false,
+  Compile / packageDoc / publishArtifact := false,
 )
 
 lazy val `external`: Project = project
   .in(file("external"))
   .enablePlugins(SbtAvro)
   .settings(commonSettings)
-  .settings(javaOnlySettings)
+  .settings(avroOnlySettings)
   .settings(
     name := "external",
     version := "0.0.1-SNAPSHOT",
-    crossScalaVersions := Seq.empty,
-    crossPaths := false,
-    autoScalaLibrary := false,
-    Compile / packageAvro / publishArtifact := true
   )
 
 lazy val `transitive`: Project = project
   .in(file("transitive"))
   .enablePlugins(SbtAvro)
   .settings(commonSettings)
-  .settings(javaOnlySettings)
+  .settings(avroOnlySettings)
   .settings(
     name := "transitive",
     version := "0.0.1-SNAPSHOT",
-    Compile / packageAvro / publishArtifact := true,
-    Test / publishArtifact := true,
     libraryDependencies ++= Seq(
-      // when using avro scope -> won't be part of the pom dependencies. intransitive
-      "com.github.sbt" % "external" % "0.0.1-SNAPSHOT" % "avro" classifier "avro",
-    )
+      // when using avro scope, it won't be part of the pom dependencies -> intransitive
+      // to declare transitive dependency use the compile scope
+      "com.github.sbt" % "external" % "0.0.1-SNAPSHOT" classifier "avro"
+    ),
+    transitiveClassifiers += "avro",
+    Compile / avroDependencyIncludeFilter := artifactFilter(classifier = "avro"),
+    // create a test jar with a schema as resource
+    Test / packageBin / publishArtifact := true,
   )
 
 lazy val root: Project = project
@@ -53,8 +57,7 @@ lazy val root: Project = project
     name := "publishing-test",
     crossScalaVersions := Seq("2.13.15", "2.12.20"),
     libraryDependencies ++= Seq(
-      "com.github.sbt" % "external" % "0.0.1-SNAPSHOT" % "avro" classifier "avro",
-      "com.github.sbt" % "transitive" % "0.0.1-SNAPSHOT" % "avro" classifier "avro",
+      "com.github.sbt" % "transitive" % "0.0.1-SNAPSHOT" % "avro" classifier "avro", // external as transitive
       "com.github.sbt" % "transitive" % "0.0.1-SNAPSHOT" % "test" classifier "tests",
       "org.specs2" %% "specs2-core" % "4.20.9" % Test
     ),

--- a/plugin/src/sbt-test/sbt-avro/publishing/transitive/src/test/resources/test.avsc
+++ b/plugin/src/sbt-test/sbt-avro/publishing/transitive/src/test/resources/test.avsc
@@ -6,10 +6,6 @@
     {
       "name": "stringField",
       "type": "string"
-    },
-    {
-      "name": "referencedTypeField",
-      "type": "com.github.sbt.avro.test.external.Avsc"
     }
   ]
 }

--- a/plugin/src/sbt-test/sbt-avro/publishing/transitive/src/test/resources/test.avsc
+++ b/plugin/src/sbt-test/sbt-avro/publishing/transitive/src/test/resources/test.avsc
@@ -6,6 +6,10 @@
     {
       "name": "stringField",
       "type": "string"
+    },
+    {
+      "name": "referencedTypeField",
+      "type": "com.github.sbt.avro.test.external.Avsc"
     }
   ]
 }


### PR DESCRIPTION
Rely on the Avro scope to compile external sources by default.

When avro sources are declared as Compile or Test dependencies, those would be fetched when depending on the default artifact (no avro classifier). The default artifact usually contains the java generated classes, hence the  the plugin should not automatically recompile those.