### PR TITLE
Allow dependency on project with avro scope

### DIFF
--- a/plugin/src/sbt-test/sbt-avro/local-dependency/build.sbt
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/build.sbt
@@ -51,37 +51,26 @@ lazy val `transitive`: Project = project
 lazy val root: Project = project
   .in(file("."))
   .enablePlugins(SbtAvro)
+  .dependsOn(`transitive` % "avro->avro")
   .settings(commonSettings)
   .settings(
-    name := "publishing-test",
+    name := "local-dependency",
     crossScalaVersions := Seq("2.13.15", "2.12.20"),
     libraryDependencies ++= Seq(
-      "com.github.sbt" % "transitive" % "0.0.1-SNAPSHOT" % "avro" classifier "avro", // external as transitive
-      "com.github.sbt" % "transitive" % "0.0.1-SNAPSHOT" % "test" classifier "tests",
       "org.specs2" %% "specs2-core" % "4.20.9" % Test
     ),
     // add additional avro source test jar
     Test / avroDependencyIncludeFilter := artifactFilter(name = "transitive", classifier = "tests"),
-    // exclude specific avsc file
-    Compile / avroUnpackDependencies / excludeFilter := (Compile / avroUnpackDependencies / excludeFilter).value || "exclude.avsc",
 
     Compile / checkUnpacked := {
-      exists(crossTarget.value / "src_managed" / "avro" / "main" / "external-avro" / "avdl.avdl")
-      exists(crossTarget.value / "src_managed" / "avro" / "main" / "external-avro" / "avpr.avpr")
-      exists(crossTarget.value / "src_managed" / "avro" / "main" / "external-avro" / "avsc.avsc")
-      absent(crossTarget.value / "src_managed" / "avro" / "main" / "external-avro" / "exclude.avsc")
-      exists(crossTarget.value / "src_managed" / "avro" / "main" / "transitive-avro" / "avsc.avsc")
+      exists((`transitive` / crossTarget).value / "src_managed" / "avro" / "main" / "external-avro" / "avdl.avdl")
+      exists((`transitive` / crossTarget).value / "src_managed" / "avro" / "main" / "external-avro" / "avpr.avpr")
+      exists((`transitive` / crossTarget).value / "src_managed" / "avro" / "main" / "external-avro" / "avsc.avsc")
     },
     Compile / checkGenerated := {
       exists(crossTarget.value / "src_managed" / "compiled_avro" / "main" / "com" / "github" / "sbt" / "avro" / "test" / "external" / "Avdl.java")
       exists(crossTarget.value / "src_managed" / "compiled_avro" / "main" / "com" / "github" / "sbt" / "avro" / "test" / "external" / "Avpr.java")
       exists(crossTarget.value / "src_managed" / "compiled_avro" / "main" / "com" / "github" / "sbt" / "avro" / "test" / "external" / "Avsc.java")
       exists(crossTarget.value / "src_managed" / "compiled_avro" / "main" / "com" / "github" / "sbt" / "avro" / "test" / "transitive" / "Avsc.java")
-    },
-    Test / checkUnpacked := {
-      exists(crossTarget.value / "src_managed" / "avro" / "test" / "transitive-tests" / "test.avsc")
-    },
-    Test / checkGenerated := {
-      exists(crossTarget.value / "src_managed" / "compiled_avro" / "test" / "com" / "github" / "sbt" / "avro" / "test" / "transitive" / "Test.java")
     }
   )

--- a/plugin/src/sbt-test/sbt-avro/local-dependency/external/src/main/avro/avdl.avdl
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/external/src/main/avro/avdl.avdl
@@ -1,0 +1,6 @@
+@namespace("com.github.sbt.avro.test.external")
+protocol ProtocolAvdl {
+    record Avdl {
+        string stringField;
+    }
+}

--- a/plugin/src/sbt-test/sbt-avro/local-dependency/external/src/main/avro/avpr.avpr
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/external/src/main/avro/avpr.avpr
@@ -1,0 +1,16 @@
+{
+    "namespace": "com.github.sbt.avro.test.external",
+    "protocol": "ProtocolAvpr",
+    "types": [
+        {
+            "name": "Avpr",
+            "type": "record",
+            "fields": [
+                {
+                    "name": "stringField",
+                    "type": "string"
+                }
+            ]
+        }
+    ]
+}

--- a/plugin/src/sbt-test/sbt-avro/local-dependency/external/src/main/avro/avsc.avsc
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/external/src/main/avro/avsc.avsc
@@ -1,0 +1,11 @@
+{
+    "name": "Avsc",
+    "namespace": "com.github.sbt.avro.test.external",
+    "type": "record",
+    "fields": [
+        {
+            "name": "stringField",
+            "type": "string"
+        }
+    ]
+}

--- a/plugin/src/sbt-test/sbt-avro/local-dependency/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.sbt" % "sbt-avro" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/plugin/src/sbt-test/sbt-avro/local-dependency/src/main/scala/com/github/sbt/avro/test/Main.scala
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/src/main/scala/com/github/sbt/avro/test/Main.scala
@@ -1,0 +1,11 @@
+package com.github.sbt.avro.test
+
+object Main extends App {
+
+  external.Avsc.newBuilder().setStringField("external").build()
+  external.Avpr.newBuilder().setStringField("external").build()
+  external.Avdl.newBuilder().setStringField("external").build()
+  transitive.Avsc.newBuilder().setStringField("transitive").build()
+
+  println("success")
+}

--- a/plugin/src/sbt-test/sbt-avro/local-dependency/src/test/scala/com/github/sbt/avro/test/AvroTest.scala
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/src/test/scala/com/github/sbt/avro/test/AvroTest.scala
@@ -1,0 +1,10 @@
+package com.github.sbt.avro.test
+
+import com.github.sbt.avro.test.transitive.Test
+
+object AvroTest extends App {
+
+  Test.newBuilder().setStringField("external").build()
+
+  println("success")
+}

--- a/plugin/src/sbt-test/sbt-avro/local-dependency/test
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/test
@@ -1,0 +1,7 @@
+> external/publishLocal
+
+> avroGenerate
+> checkUnpacked
+> checkGenerated
+
+> +compile

--- a/plugin/src/sbt-test/sbt-avro/local-dependency/transitive/src/main/avro/com/github/sbt/avro/test/transitive/avsc.avsc
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/transitive/src/main/avro/com/github/sbt/avro/test/transitive/avsc.avsc
@@ -1,0 +1,15 @@
+{
+  "name": "Avsc",
+  "namespace": "com.github.sbt.avro.test.transitive",
+  "type": "record",
+  "fields": [
+    {
+      "name": "stringField",
+      "type": "string"
+    },
+    {
+      "name": "referencedTypeField",
+      "type": "com.github.sbt.avro.test.external.Avsc"
+    }
+  ]
+}

--- a/plugin/src/sbt-test/sbt-avro/local-dependency/transitive/src/test/resources/test.avsc
+++ b/plugin/src/sbt-test/sbt-avro/local-dependency/transitive/src/test/resources/test.avsc
@@ -1,0 +1,15 @@
+{
+  "name": "Test",
+  "namespace": "com.github.sbt.avro.test.transitive",
+  "type": "record",
+  "fields": [
+    {
+      "name": "stringField",
+      "type": "string"
+    },
+    {
+      "name": "referencedTypeField",
+      "type": "com.github.sbt.avro.test.external.Avsc"
+    }
+  ]
+}


### PR DESCRIPTION
this allows local project to use `dependsOn(module % "avro->avro")` that behaves like a module declared with the avro scope