### PR TITLE
Don't close URLClassLoader

### DIFF
--- a/bridge/src/main/java/com/github/sbt/avro/AvroCompilerBridge.java
+++ b/bridge/src/main/java/com/github/sbt/avro/AvroCompilerBridge.java
@@ -96,16 +96,11 @@ public class AvroCompilerBridge implements AvroCompiler {
 
     @Override
     public void compileAvscs(File[] avscs, File target) throws Exception {
-        List<File> files = new ArrayList<>(avscs.length);
-        for (File schema : avscs) {
-            System.out.println("Compiling Avro schema: " + schema);
-            files.add(schema);
-        }
-        Map<File, Schema> schemas = parser.parseFiles(files);
-
+        Map<File, Schema> schemas = parser.parseFiles(Arrays.asList(avscs));
         for (Map.Entry<File, Schema> entry: schemas.entrySet()) {
             File file = entry.getKey();
             Schema schema = entry.getValue();
+            System.out.println("Compiling Avro schema: " + file + ":" + schema.getFullName());
             SpecificCompiler compiler = new SpecificCompiler(schema);
             configureCompiler(compiler);
             compiler.compileToDestination(file, target);
@@ -119,7 +114,7 @@ public class AvroCompilerBridge implements AvroCompiler {
             Protocol protocol = Protocol.parse(avpr);
             SpecificCompiler compiler = new SpecificCompiler(protocol);
             configureCompiler(compiler);
-            compiler.compileToDestination(null, target);
+            compiler.compileToDestination(avpr, target);
         }
     }
 }

--- a/plugin/src/main/scala/com/github/sbt/avro/SbtAvro.scala
+++ b/plugin/src/main/scala/com/github/sbt/avro/SbtAvro.scala
@@ -242,8 +242,6 @@ object SbtAvro extends AutoPlugin {
                 // - no previous cache and we have records to recompile
                 // - input files have changed
                 // - output files are missing
-
-                // TODO Cache class loader
                 val avroClassLoader = new AvroCompilerPluginClassLoader(
                   (AvroCompiler / dependencyClasspath).value
                     .map(toNioPath)
@@ -287,7 +285,6 @@ object SbtAvro extends AutoPlugin {
                     throw new AvroGenerateFailedException
                 } finally {
                   Thread.currentThread().setContextClassLoader(initLoader)
-                  avroClassLoader.close()
                 }
               } else {
                 outReport.checked


### PR DESCRIPTION
Closing the URLClassLoader seems to create an issue due to concurrency nature of sbt. When another ClassLoader accesses a resource, the stream is closed unexpectedly.

Change schema logging to better represent concurrent execution.