### PR TITLE
Scope avroGenerate cache by Scala version to fix cross-compilation race

### DIFF
--- a/plugin/src/main/scala/com/github/sbt/avro/SbtAvro.scala
+++ b/plugin/src/main/scala/com/github/sbt/avro/SbtAvro.scala
@@ -213,6 +213,14 @@ object SbtAvro extends AutoPlugin {
       val projectFilter = ScopeFilter(avroProjectIncludeFilter.value, inConfigurations(Compile))
       Def.task {
         val out = (avroGenerate / streams).value
+        val cacheDir = Defaults.makeCrossTarget(
+          out.cacheDirectory,
+          scalaVersion.value,
+          scalaBinaryVersion.value,
+          (pluginCrossBuild / sbtBinaryVersion).value,
+          sbtPlugin.value,
+          crossPaths.value
+        )
         val externalSrcDir = (avroUnpackDependencies / target).value
         val unmanagedSrcDirs = avroUnmanagedSourceDirectories.value
 
@@ -230,7 +238,7 @@ object SbtAvro extends AutoPlugin {
           import sbt.util.CacheStoreFactory
           import sbt.util.CacheImplicits._
 
-          val cacheStoreFactory = CacheStoreFactory(out.cacheDirectory / "avro")
+          val cacheStoreFactory = CacheStoreFactory(cacheDir / "avro")
           val lastCache = { (action: Option[Set[File]] => Set[File]) =>
             Tracked
               .lastOutput[Unit, Set[File]](cacheStoreFactory.make("last-cache")) { case (_, l) =>

--- a/plugin/src/main/scala/com/github/sbt/avro/SbtAvro.scala
+++ b/plugin/src/main/scala/com/github/sbt/avro/SbtAvro.scala
@@ -212,7 +212,7 @@ object SbtAvro extends AutoPlugin {
     Def.taskDyn[Seq[File]] {
       val projectFilter = ScopeFilter(avroProjectIncludeFilter.value, inConfigurations(Compile))
       Def.task {
-        val out = (avroGenerate / streams).value
+        val out = streams.value
         val cacheDir = Defaults.makeCrossTarget(
           out.cacheDirectory,
           scalaVersion.value,


### PR DESCRIPTION
The sourceGeneratorTask cache was stored at a path not scoped to the Scala version
This cased the pass for one Scala version during +publishLocal to hit cache of another Scala version and skip regeneration. 

This seems to have been introduced in https://github.com/sbt/sbt-avro/pull/255. 
Re-introduce _some_ recompilation of Avro schemas, but only to avoid race conditions during cross-compilation.

Apply the same makeCrossTarget pattern already used in unpackDependenciesTask.

---

### Why?

In a multiple real world sbt project that cross-compile between Scala 2.12 and 2.13, we have observed 7-8% build failures because of the current behavior, across ~200 test iterations. Similar frequency has been observed in CI.

With this change, 30 iterations have succeeded.

The iteration loop was

1. sbt clean
2. sbt compile      ← prime for 2.12
3. sbt +publishLocal ← cross-publish, race window

---

### Performance

A clean compilation now looks to be ~60% slower for a project that cross-compiles between two versions.

In a project without cross-compilation, there is some performance degradation:
1. sbt clean
2. sbt compile 
3. sbt test:compile 

```
  │ Phase            │ Baseline │ This PR│ Delta      │
  │ sbt compile      │ 12s      │ 13s    │ +1s (+8%)  │
  │ sbt test:compile │ 4s       │ 5s     │ +1s (+25%) │
  │ Per iteration    │ ~17s     │ ~18s   │ +1s (+6%)  │
  │ 10-iter total    │ 173s     │ 184s   │ +11s       │
```
